### PR TITLE
Actions undo/redo, mode independent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.uniwue</groupId>
     <artifactId>Larex</artifactId>
-    <version>0.1.8-5</version>
+    <version>0.1.8-6</version>
     <packaging>war</packaging>
 
     <name>Larex</name>

--- a/src/main/webapp/resources/js/viewer/actions.js
+++ b/src/main/webapp/resources/js/viewer/actions.js
@@ -286,7 +286,8 @@ function ActionRemoveSegment(segment, editor, textViewer, segmentation, page, co
 	if(_segment.textlines != null){
 		const ids = Object.keys(_segment.textlines);
 		for(const [index,id] of ids.entries()){
-			_actionRemoveTextLines.push(new ActionRemoveTextLine(_segment.textlines[id], editor, textViewer, segmentation, page, controller, selector,(index === ids.length-1 || index==0)));
+			_actionRemoveTextLines.push(new ActionRemoveTextLine(_segment.textlines[id], editor, textViewer, segmentation,
+				page, controller, selector,(index === ids.length-1 || index==0)));
 		}	
 	}
 	const multiRemove = new ActionMultiple(_actionRemoveTextLines);
@@ -306,6 +307,11 @@ function ActionRemoveSegment(segment, editor, textViewer, segmentation, page, co
 
 			if(_actionRemoveFromReadingOrder)
 				_actionRemoveFromReadingOrder.execute();
+
+			const mode = controller.getMode();
+			if(mode == Mode.EDIT || mode == Mode.SEGMENT)
+				controller.forceUpdateReadingOrder(doForceUpdate);
+			
 
 			editor.removeSegment(_segment.id);
 			selector.unSelectSegment(_segment.id);
@@ -667,7 +673,8 @@ function ActionRemoveFromReadingOrder(id, page, segmentation, controller, doForc
 
 			if(!(JSON.stringify(_newReadingOrder) == JSON.stringify(_oldReadingOrder))){
 				segmentation[page].readingOrder = JSON.parse(JSON.stringify(_newReadingOrder));
-				if(doForceUpdate)
+				const mode = controller.getMode();
+				if(doForceUpdate && (mode == Mode.EDIT || mode == Mode.SEGMENT))
 					controller.forceUpdateReadingOrder(true);
 				console.log('Do - Remove from Reading Order: {id:"' + id + '",[..]}');
 			}

--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -684,10 +684,10 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 				} else {
 					if(selectType === ElementType.SEGMENT){
 						let segment = _segmentation[_currentPage].segments[selected[0]];
-						_actionController.addAndExecuteAction(new ActionRemoveSegment(segment, _editor, _textViewer, _segmentation, _currentPage, this, _selector), _currentPage);
+						_actionController.addAndExecuteAction(new ActionRemoveSegment(segment, _editor, _textViewer, _segmentation, _currentPage, this, _selector, true), _currentPage);
 					} else {
 						let segment = _segmentation[_currentPage].segments[this.textlineRegister[selected[0]]].textlines[selected[0]];
-						_actionController.addAndExecuteAction(new ActionRemoveTextLine(segment, _editor, _textViewer, _segmentation, _currentPage, this, _selector), _currentPage);
+						_actionController.addAndExecuteAction(new ActionRemoveTextLine(segment, _editor, _textViewer, _segmentation, _currentPage, this, _selector, true), _currentPage);
 					}
 
 				}
@@ -1229,17 +1229,20 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 	this.updateTextLine = function(id) {
 		if(this.getIDType(id) === ElementType.TEXTLINE){
 			const textline = _segmentation[_currentPage].segments[this.textlineRegister[id]].textlines[id];
-			const hasGT = 0 in textline.text;
-			if(hasGT){
-				textline.type = "TextLine_gt";
-			} else {
-				textline.type = "TextLine";
+			// Check if the update request came for a deleted textline
+			if(textline){
+				const hasGT = 0 in textline.text;
+				if(hasGT){
+					textline.type = "TextLine_gt";
+				} else {
+					textline.type = "TextLine";
+				}
+				_editor.updateSegment(textline);
+
+				_gui.updateTextLine(id);
+
+				_textViewer.updateTextline(textline);
 			}
-			_editor.updateSegment(textline);
-
-			_gui.updateTextLine(id);
-
-			_textViewer.updateTextline(textline);
 		}
 	}
 	/**

--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -692,13 +692,13 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 
 				}
 			}
-		}else{
+		} else {
 			//Polygon is selected => Delete polygon
 			const actions = [];
 			for (let i = 0, selectedlength = selected.length; i < selectedlength; i++) {
 				if (selectType === ElementType.REGION) {
 					actions.push(new ActionRemoveRegion(this._getRegionByID(selected[i]), _editor, _settings, _currentPage, this));
-				} else if (selectType === ElementType.SEGMENT) {
+				} else if (selectType === ElementType.SEGMENT && (_mode == Mode.SEGMENT || _mode == Mode.EDIT)) {
 					let segment = _segmentation[_currentPage].segments[selected[i]];
 					actions.push(new ActionRemoveSegment(segment, _editor, _textViewer, _segmentation, _currentPage, this, _selector, (i == selected.length-1 || i == 0)));
 				} else if (selectType === ElementType.CUT) {
@@ -1175,9 +1175,14 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 							// Sort and retrieve most represented/dominant parent
 							[segmentID,_] = [...Object.entries(parents_counter)].sort((a, b) => b[1] - a[1])[0];
 						}
-						const segment = _segmentation[_currentPage].segments[segmentID];
-						readingOrder = (segment.readingOrder || []);
-						_gui.setReadingOrder(readingOrder, segment.textlines);
+						// Undefined segmentID points to non TextRegion region
+						if(segmentID) {
+							const segment = _segmentation[_currentPage].segments[segmentID];
+							readingOrder = (segment.readingOrder || []);
+							_gui.setReadingOrder(readingOrder, segment.textlines);
+						} else {
+							_gui.setReadingOrder(readingOrder, []);
+						}
 					} else {
 						_gui.setReadingOrder([], {}, warning="Please select a segment");
 					}

--- a/src/main/webapp/resources/js/viewer/selector.js
+++ b/src/main/webapp/resources/js/viewer/selector.js
@@ -209,6 +209,7 @@ class Selector {
 		if(segmentation){
 			if(type === ElementType.SEGMENT){
 				order = segmentation.readingOrder ? JSON.parse(JSON.stringify(segmentation.readingOrder)) : [];
+				order.filter(id => Object.keys(segmentation.segments).includes(id));
 				let segments = Object.entries(segmentation.segments).map(([_,s]) => s)
 												.filter(s => !order.includes(s.id));
 				// Add segments anchors to compare
@@ -234,22 +235,24 @@ class Selector {
 			} else if (type === ElementType.TEXTLINE) {
 				const segments = parentID ? [parentID] : this.getSelectOrder(ElementType.SEGMENT);
 				for(const id of segments){
-					const textlinesRO = segmentation.segments[id].readingOrder;
-					if(textlinesRO && textlinesRO.length > 0){
-						order = order.concat(textlinesRO);
-					}
-
-					// Add sorted textlines
-					if(segmentation.segments[id].textlines){
-						let textlines = Object.entries(segmentation.segments[id].textlines).map(([_,t]) => t);
-						if(textlinesRO){
-							textlines = textlines.filter(t => !textlinesRO.includes(t.id));
+					if(Object.keys(segmentation.segments).includes(id)){
+						const textlinesRO = segmentation.segments[id].readingOrder;
+						if(textlinesRO && textlinesRO.length > 0){
+							order = order.concat(textlinesRO);
 						}
-						if(textlines && textlines.length > 0){
-							for(const textline of textlines){
-								addCompare(textline);
+
+						// Add sorted textlines
+						if(segmentation.segments[id].textlines){
+							let textlines = Object.entries(segmentation.segments[id].textlines).map(([_,t]) => t);
+							if(textlinesRO){
+								textlines = textlines.filter(t => !textlinesRO.includes(t.id));
 							}
-							order = order.concat(textlines.sort(tlbr).map(l => l.id));
+							if(textlines && textlines.length > 0){
+								for(const textline of textlines){
+									addCompare(textline);
+								}
+								order = order.concat(textlines.sort(tlbr).map(l => l.id));
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Fixed some undo->redo problems of some actions in specific views.

e.g. Remove region in `Segment`/`Edit` view, than undo and redo this action in `Lines` view.
This could potentially result in errors.