### PR TITLE
Add dependency for JDK 11 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,11 @@
             <artifactId>Maths</artifactId>
             <version>1.4.02</version>
         </dependency>
-
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>


### PR DESCRIPTION
Since JDK11, various Java EE components were moved from the standard library to external packages, including `javax.annotation`. This PR fixes compilation with JDK 11.