### PR TITLE
feature/tiff support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,18 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- Java Advanced Imaging (JAI) Image I/O Tools -->
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-core</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-jpeg2000</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>


### PR DESCRIPTION
Addresses the issue described in #216 where e.g. opening TIFF image files is causing LAREX to "crash" as ImageIO doesn't natively support reading e.g. TIFF image files with Java 8. Adding Java Advanced Imaging (JAI) Image I/O Tools fixes this.
JAI should be removed when migrating to >Java 8 as native TIFF support is added starting from Java 9. 