### PR TITLE
Fix/invalid xml handling

### DIFF
--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -34,7 +34,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 	let _newPolygonCounter = 0;
 	let _pastId;
 	let _initialTextView = true;
-	let _imageVersion = 0;
+	this._imageVersion = 0;
 
 	// Unsaved warning
 	window.onbeforeunload = () =>  {
@@ -149,7 +149,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		});
 	});
 
-	this.displayPage = function (pageNr, imageNr=_imageVersion) {
+	this.displayPage = function (pageNr, imageNr=this._imageVersion, empty=false) {
 		this.escape();
 		_currentPage = pageNr;
 		_gui.updateSelectedPage(_currentPage);
@@ -185,7 +185,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		// Check if page is to be segmented or if segmentation can be loaded
 		if (_segmentedPages.indexOf(_currentPage) < 0 && _savedPages.indexOf(_currentPage) < 0) {
 			_communicator.getHaveAnnotations(_book.id).done((pages) =>{
-				if(_allowLoadLocal && pages.includes(_currentPage)){
+				if(_allowLoadLocal && pages.includes(_currentPage) && !empty){
 					this.loadAnnotations();
 				} else if(_autoSegment){
 					this.requestSegmentation();
@@ -275,7 +275,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 	}
 
 	this.setImageVersion = function(imageVersion) {
-		_imageVersion = imageVersion;
+		this._imageVersion = imageVersion;
 	}
 
 	this.redo = function () {
@@ -301,8 +301,14 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		_actionController.resetActions(_currentPage);
 		//Update setting parameters
 		_communicator.getPageAnnotations(_book.id, _currentPage).done((result) => {
-			this._setPage(_currentPage, result);
-			this.displayPage(_currentPage);
+			if(!result){
+				_gui.displayWarning("Couldn't retrieve annotations from file.");
+				this.displayPage(_currentPage, this._imageVersion, true);
+			}else{
+				this._setPage(_currentPage, result);
+				this.displayPage(_currentPage);
+			}
+
 		});
 	}
 
@@ -445,8 +451,13 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		this.showPreloader(true);
 
 		_communicator.uploadPageXML(file, _currentPage, _book.id).done((page) => {
-			this._setPage(_currentPage,page);
-			this.displayPage(_currentPage);
+			if(!page){
+				_gui.displayWarning("Couldn't retrieve annotations from file.");
+				this.displayPage(_currentPage, this._imageVersion, true);
+			}else{
+				this._setPage(_currentPage,page);
+				this.displayPage(_currentPage);
+			}
 			this.showPreloader(false);
 		});
 	}

--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -303,7 +303,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		//Update setting parameters
 		_communicator.getPageAnnotations(_book.id, _currentPage).done((result) => {
 			if(!result){
-				_gui.displayWarning("Couldn't retrieve annotations from file.");
+				_gui.displayWarning("Couldn't retrieve annotations from file.", 4000, "red");
 				this.displayPage(_currentPage, this._imageVersion, true);
 			}else{
 				this._setPage(_currentPage, result);
@@ -345,7 +345,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 				// }
 			}
 			this.displayPage(pages[0])
-			Materialize.toast("Batch segmentation successful.", 1500, "green")
+			_gui.displayWarning("Batch segmentation successful.", 1500, "green")
 			_batchSegmentationPreloader.hide();
 			$(".modal").modal("close");
 		});
@@ -453,7 +453,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 
 		_communicator.uploadPageXML(file, _currentPage, _book.id).done((page) => {
 			if(!page){
-				_gui.displayWarning("Couldn't retrieve annotations from file.");
+				_gui.displayWarning("Couldn't retrieve annotations from file.", 4000, "red");
 				this.displayPage(_currentPage, this._imageVersion, true);
 			}else{
 				this._setPage(_currentPage,page);

--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -224,8 +224,9 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 			// Iterate over Regions-"Map" (Object in JS)
 			Object.keys(regions).forEach((key) => {
 				const region = regions[key];
-				if(!_colors.hasColor(region.type));
+				if(!_colors.hasColor(region.type)){
 					_colors.assignAvailableColor(region.type);
+				}
 
 				// Iterate over all Areas of a Region
 				Object.keys(region.areas).forEach((areaKey) => {

--- a/src/main/webapp/resources/js/viewer/gui.js
+++ b/src/main/webapp/resources/js/viewer/gui.js
@@ -901,8 +901,8 @@ function GUI(canvas, viewer, colors, accessible_modes) {
 			$('.saveSettingsXML').find('.progress').addClass('hide');
 		}
 	}
-	this.displayWarning = function (text) {
-		Materialize.toast(text, 4000);
+	this.displayWarning = function (text, time=4000, color="grey darken-4") {
+		Materialize.toast(text, time, color);
 		console.warn(text);
 	}
 


### PR DESCRIPTION
Fixes the problem described in #216 where invalid XML files lead to an error and the display of an infinite buffering icon.
In case no annotation can be loaded from the local XML file LAREX will display an error message (as Materialize toast) but still allow normal editing (running the segmentation, manual segmentation, loading another XML file, etc.)
 