### PR TITLE
fix/reading order

### DIFF
--- a/src/main/webapp/resources/js/viewer/editor.js
+++ b/src/main/webapp/resources/js/viewer/editor.js
@@ -1053,7 +1053,11 @@ getSortedReadingOrder(readingOrder, polygons) {
 	const centers = {};
 	for (let index = 0; index < readingOrder.length; index++) {
 		const id = readingOrder[index];
-		centers[id] = this._center(polygons[index]);
+		if(polygons){
+			centers[id] = this._center(polygons[index]);
+		}else{
+			centers[id] = this.getPolygon(id).bounds.center;
+		}
 	}
 
 	readingOrder.sort(function (a, b) {


### PR DESCRIPTION
Fixes a bug which made it unable to add several selected segments to the reading order by accounting for function calls without a `polygons` argument which was introduced to `getSortedReadingOrder` during adding batch segmentation