### PR TITLE
correctly set the page for empty results

### DIFF
--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -504,6 +504,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 					preparePage(this);
 					break;
 				case 'SUCCESS':
+				case 'EMPTY':
 					preparePage(this);
 					break;
 				default:


### PR DESCRIPTION
fixes a bug where the result of an empty segmentation wasn't correctly processed by `_setPage` and manually annotating the page wasn't possible anymore because `_segmentation` was undefined for the current page (see: #231)