### PR TITLE
Fix/check seg before ro

### DIFF
--- a/src/main/java/de/uniwue/web/communication/BatchLoadRequest.java
+++ b/src/main/java/de/uniwue/web/communication/BatchLoadRequest.java
@@ -1,0 +1,36 @@
+package de.uniwue.web.communication;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.uniwue.web.model.PageAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Communication object for the gui to request the export of different
+ * pages. Contains a list of page numbers to
+ * export and page annotations for each page.
+ *
+ */
+public class BatchLoadRequest {
+    @JsonProperty("bookid")
+    private Integer bookid;
+    @JsonProperty("pages")
+    private List<Integer> pages;
+
+    @JsonCreator
+    public BatchLoadRequest(@JsonProperty("bookid") Integer bookid,
+                              @JsonProperty("pages") List<Integer> pages) {
+        this.bookid = bookid;
+        this.pages = pages;
+    }
+    public Integer getBookid() {
+        return bookid;
+    }
+
+    public List<Integer> getPages() {
+        return pages;
+    }
+
+}

--- a/src/main/webapp/WEB-INF/tags/batchSegmentModal.tag
+++ b/src/main/webapp/WEB-INF/tags/batchSegmentModal.tag
@@ -12,12 +12,6 @@
                 <div class="collapsible-body collapsible-body-batch">
                     <ul>
                         <li>
-                            <input type="checkbox" class="modeSelect" id="batchLoad"/>
-                            <label for="batchLoad">
-                                Auto Load
-                            </label>
-                        </li>
-                        <li>
                             <input type="checkbox" class="modeSelect" id="batchSegmentation"/>
                             <label for="batchSegmentation">
                                 Segment pages

--- a/src/main/webapp/WEB-INF/tags/batchSegmentModal.tag
+++ b/src/main/webapp/WEB-INF/tags/batchSegmentModal.tag
@@ -12,6 +12,12 @@
                 <div class="collapsible-body collapsible-body-batch">
                     <ul>
                         <li>
+                            <input type="checkbox" class="modeSelect" id="batchLoad"/>
+                            <label for="batchLoad">
+                                Auto Load
+                            </label>
+                        </li>
+                        <li>
                             <input type="checkbox" class="modeSelect" id="batchSegmentation"/>
                             <label for="batchSegmentation">
                                 Segment pages
@@ -66,7 +72,7 @@
     </div>
     <div class="modal-footer">
         <a href="#!" class="modal-close waves-effect waves-green btn-flat">Close</a>
-        <a id="batchNext" class="disabled col s12 waves-effect waves-light btn confirmBatchSegment tooltipped"
+        <a id="batchNext" class="disabled col s12 waves-effect waves-light btn confirmBatchSegment tooltipped autoLoadPagesBatch"
            href="#batchSegmentConfirmationModal" data-position="left" data-delay="50"
            data-tooltip="Run the batch segmentation">Next</a>
     </div>
@@ -85,7 +91,7 @@
             <div class="determinate"></div>
         </div>
         <div class="center">
-            <a class="col s12 waves-effect waves-light btn doBatchSegment tooltipped" data-position="left"
+            <a id="runBatch" class="col s12 waves-effect waves-light btn doBatchSegment tooltipped" data-position="left"
                data-delay="50" data-tooltip="Run the batch segmentation">Run<i class="material-icons right">send</i></a>
             <a href="#!" class="modal-close btn waves-effect waves-light red">Abort</a>
         </div>

--- a/src/main/webapp/resources/js/viewer/communicator.js
+++ b/src/main/webapp/resources/js/viewer/communicator.js
@@ -60,6 +60,10 @@ class Communicator {
 		return this.request("data/page/annotations", {bookid:bookid, pageid:pageid});
 	}
 
+	getPageAnnotationsBatch(bookid, pages) {
+		return this.request("data/page/batchAnnotations", {bookid:bookid, pages:pages}, DataType.JSON);
+	}
+
 	getHaveAnnotations(bookID) { 
 		return this.request("data/status/all/annotations", {bookid:bookID});
 	}

--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -359,19 +359,18 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		});
 	}
 	this.batchGenerateReadingOrder = function ( pages, roMode) {
-		let segPages = this.checkPagesForSegmentation(pages);
-		if(segPages.length != 0) {
+		if(pages.length != 0) {
 			switch (roMode) {
 				case "automatic":
-					this.batchAutoReadingOrder(segPages);
+					this.batchAutoReadingOrder(pages);
 					break;
 				default:
 					console.log("Reading order '" + roMode +  "'defaults to automatic");
-					this.batchAutoReadingOrder(segPages);
+					this.batchAutoReadingOrder(pages);
 					break;
 			}
-			for (let index in segPages) {
-				this.setChanged(segPages[index]);
+			for (let i = 0; i < pages.length; i++) {
+				this.setChanged(pages[i]);
 			}
 			_gui.displayWarning("Batch Reading Order successful.", 1500, "green")
 		} else {
@@ -379,8 +378,14 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		}
 	}
 	this.batchAutoReadingOrder = function (pages) {
-		for(let page in pages) {
-			this.autoGenerateReadingOrder(pages[page]);
+		for(let i = 0; i<pages.length; i++) {
+			try {
+				this.autoGenerateReadingOrder(pages[i]);
+			} catch (e) {
+				console.log("page " + i + " could not be loaded!")
+				console.log(e);
+			}
+
 		}
 	}
 	this.checkPagesForSegmentation = function (pages) {
@@ -399,9 +404,50 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 
 		return segPages;
 	}
+
+	this.loadMultiplePagesIntoSession = function (pages) {
+		_communicator.getPageAnnotationsBatch(_book.id, pages).done((result) => {
+			if(!result){
+				console.log("Server error while loading pages");
+			}else{
+				for(let i = 0; i < pages.length; i++) {
+					_actionController.resetActions(pages[i]);
+					this._setPage(pages[i], result[i]);
+				}
+			}
+			_gui.updateSelectedPage(_currentPage);
+			$("#runBatch").removeClass("disabled");
+		});
+	}
+	this.handleBatch = function (selected_pages, doReadingOrder, roMode, batchSeg, batchExp) {
+		let progress = 0;
+		let progressInterval = setInterval(() => {
+			_communicator.getBatchSegmentationProgress().done(function (data) {
+				setTimeout(function () {
+					progress = Math.round((data / selected_pages.toArray().length) * 100);
+					console.log("progress: " + progress);
+					$("#batch-segmentation-progress").css('width', progress + '%');
+				});
+			})
+		},1000)
+
+		if(batchSeg) {
+			this.requestBatchSegmentation(false, selected_pages.toArray(), $("#batchSaveSegmentation").is(":checked"),progressInterval,doReadingOrder,roMode);
+		}else if(batchExp && !(batchSeg)) {
+			selected_pages = this.checkPagesForSegmentation(selected_pages);
+			this.requestBatchExport(selected_pages,progressInterval, doReadingOrder, roMode);
+		}else if(!(batchExp) && !(batchSeg) && doReadingOrder) {
+			selected_pages = this.checkPagesForSegmentation(selected_pages);
+			clearInterval(progressInterval);
+			$(".modal").modal("close");
+			if(this.getLoadLocalSetting()) {
+				this.toggleLoadExistingSegmentation(false, true)
+			}
+			this.batchGenerateReadingOrder(selected_pages,roMode);
+		}
+	}
 	this.requestBatchExport = function (pages, progressInterval, doReadingOrder, roMode) {
-		let segPages = this.checkPagesForSegmentation(pages);
-		if(segPages.length == 0) {
+		if(pages.length == 0) {
 			clearInterval(progressInterval);
 			$("#batch-segmentation-progress").css('width', '0%');
 			$(".modal").modal("close");
@@ -409,7 +455,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 			return;
 		}
 		if(doReadingOrder) {
-			this.batchGenerateReadingOrder(segPages,roMode);
+			this.batchGenerateReadingOrder(pages,roMode);
 		}
 		const _batchSegmentationPreloader = $("#batch-segmentation-progress")
 		_batchSegmentationPreloader.show();
@@ -417,13 +463,13 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		//Update setting parameters
 		_settings.parameters = _gui.getParameters();
 		let segmentations = [];
-		for(let pageI in segPages) {
-			segmentations.push(_segmentation[segPages[pageI]]);
+		for(let pageI in pages) {
+			segmentations.push(_segmentation[pages[pageI]]);
 		}
-		_communicator.batchExportPage(_book.id, segPages,segmentations,_gui.getPageXMLVersion()).then((data) => {
-			for(let pageI in segPages) {
-				_savedPages.push(segPages[pageI]);
-				_gui.addPageStatus(segPages[pageI],PageStatus.SERVERSAVED);
+		_communicator.batchExportPage(_book.id, pages,segmentations,_gui.getPageXMLVersion()).then((data) => {
+			for(let pageI in pages) {
+				_savedPages.push(pages[pageI]);
+				_gui.addPageStatus(pages[pageI],PageStatus.SERVERSAVED);
 			}
 
 			if(globalSettings.downloadPage) {
@@ -439,7 +485,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 				}
 			}
 		});
-		this.displayPage(segPages[0])
+		this.displayPage(pages[0])
 		clearInterval(progressInterval);
 		_batchSegmentationPreloader.hide();
 		$("#batch-segmentation-progress").css('width', '0%');

--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -432,6 +432,8 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		});
 	}
 	this.handleBatch = function (selected_pages, doReadingOrder, roMode, batchSeg, batchExp) {
+		this.loadMultiplePagesIntoSession(selected_pages.toArray());
+
 		let progress = 0;
 		let progressInterval = setInterval(() => {
 			_communicator.getBatchSegmentationProgress().done(function (data) {

--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -36,6 +36,18 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 	let _initialTextView = true;
 	this._imageVersion = 0;
 
+	this.get_segmentation = function(){
+		return _segmentation
+	}
+
+	this.get_saved_pages = function(){
+		return _savedPages;
+	}
+
+	this.get_segmented_pages = function(){
+		return _segmentedPages;
+	}
+
 	// Unsaved warning
 	window.onbeforeunload = () =>  {
 		if(!this.isCurrentPageSaved() && _actionController.hasActions(_currentPage)){
@@ -563,7 +575,7 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 				default:
 			}
 
-			_segmentedPages.push(_currentPage);
+			_segmentedPages.push(pageid);
 			if (missingRegions.length > 0) {
 				_gui.displayWarning('Warning: Some regions were missing and have been added.');
 			}

--- a/src/main/webapp/resources/js/viewer/guiInput.js
+++ b/src/main/webapp/resources/js/viewer/guiInput.js
@@ -492,34 +492,24 @@ function GuiInput(navigationController, controller, gui, textViewer, selector, c
 		const selected_pages = $('.batchPageCheck:checkbox:checked').map(function(){
 			return $(this).data("page");
 		});
+
+		let sel_pages = _controller.checkPagesForSegmentation(selected_pages.toArray());
 		let doReadingOrder = $("#selectReadingOrder").is(":checked");
 		let roMode = $("#select-ro-option").val();
 		let batchSeg = $("#batchSegmentation").is(":checked");
 		let batchExp = $("#batchSaveSegmentation").is(":checked");
-		let progress = 0;
-		let progressInterval = setInterval(() => {
-			_communicator.getBatchSegmentationProgress().done(function (data) {
-				setTimeout(function () {
-					progress = Math.round((data / selected_pages.toArray().length) * 100);
-					console.log("progress: " + progress);
-					$("#batch-segmentation-progress").css('width', progress + '%');
-				});
-			})
-		},1000)
-		if(batchSeg) {
-			_controller.requestBatchSegmentation(false, selected_pages.toArray(), $("#batchSaveSegmentation").is(":checked"),progressInterval,doReadingOrder,roMode);
-		}else if(batchExp && !(batchSeg)) {
-			_controller.requestBatchExport(selected_pages.toArray(),progressInterval, doReadingOrder, roMode);
-		}else if(!(batchExp) && !(batchSeg) && doReadingOrder) {
-			_controller.batchGenerateReadingOrder(selected_pages.toArray(),roMode);
-			clearInterval(progressInterval);
-			$(".modal").modal("close");
-			if(_controller.getLoadLocalSetting()) {
-				_controller.toggleLoadExistingSegmentation(false, true)
-			}
+
+		_controller.handleBatch(selected_pages, doReadingOrder, roMode, batchSeg, batchExp);
+	});
+	$(".autoLoadPagesBatch").click(function (){
+		if($("#batchLoad").is(":checked")) {
+			$("#runBatch").addClass("disabled");
+			const selected_pages = $('.batchPageCheck:checkbox:checked').map(function(){
+				return $(this).data("page");
+			});
+			_controller.loadMultiplePagesIntoSession(selected_pages.toArray());
 		}
 	});
-
 	$("#displayPrediction").click(function(){
 		_textViewer._displayPredictedText();
 	})

--- a/src/main/webapp/resources/js/viewer/guiInput.js
+++ b/src/main/webapp/resources/js/viewer/guiInput.js
@@ -501,15 +501,6 @@ function GuiInput(navigationController, controller, gui, textViewer, selector, c
 
 		_controller.handleBatch(selected_pages, doReadingOrder, roMode, batchSeg, batchExp);
 	});
-	$(".autoLoadPagesBatch").click(function (){
-		if($("#batchLoad").is(":checked")) {
-			$("#runBatch").addClass("disabled");
-			const selected_pages = $('.batchPageCheck:checkbox:checked').map(function(){
-				return $(this).data("page");
-			});
-			_controller.loadMultiplePagesIntoSession(selected_pages.toArray());
-		}
-	});
 	$("#displayPrediction").click(function(){
 		_textViewer._displayPredictedText();
 	})


### PR DESCRIPTION
- adds toggle to automatically load missing page annotations from server when doing a batch operation
- fixes bug where page index was used instead of page number
- corrects behavior where whole batch will be rejected when one page is missing. Now only available pages from the session (and from server if 'auto load' is enabled) will be send as batch.