### PR TITLE
Use XML files in savedir when loading annotations

### DIFF
--- a/src/main/java/de/uniwue/web/controller/DataController.java
+++ b/src/main/java/de/uniwue/web/controller/DataController.java
@@ -52,8 +52,12 @@ public class DataController {
 		if (!config.isInitiated()) {
 			config.read(new File(fileManager.getConfigurationFile()));
 			String bookFolder = config.getSetting("bookpath");
+			String saveDir = config.getSetting("savedir");
 			if (!bookFolder.equals("")) {
 				fileManager.setLocalBooksPath(bookFolder);
+			}
+			if (saveDir != null && !saveDir.equals("")) {
+				fileManager.setSaveDir(saveDir);
 			}
 		}
 	}

--- a/src/main/java/de/uniwue/web/controller/FileController.java
+++ b/src/main/java/de/uniwue/web/controller/FileController.java
@@ -87,8 +87,12 @@ public class FileController {
 		if (!config.isInitiated()) {
 			config.read(new File(fileManager.getConfigurationFile()));
 			String bookFolder = config.getSetting("bookpath");
+			String saveDir = config.getSetting("savedir");
 			if (!bookFolder.equals("")) {
 				fileManager.setLocalBooksPath(bookFolder);
+			}
+			if (saveDir != null && !saveDir.equals("")) {
+				fileManager.setSaveDir(saveDir);
 			}
 		}
 		this.exportProgress = 0;
@@ -364,9 +368,10 @@ public class FileController {
 	}
 
 	private void saveDocument(Document pageXML, String xmlName, Integer bookid) {
+		FileDatabase database;
 		switch (config.getSetting("localsave")) {
 			case "bookpath":
-				FileDatabase database = new FileDatabase(new File(fileManager.getLocalBooksPath()),
+				database = new FileDatabase(new File(fileManager.getLocalBooksPath()),
 						config.getListSetting("imagefilter"));
 
 				String bookdir = fileManager.getLocalBooksPath() + File.separator
@@ -374,8 +379,12 @@ public class FileController {
 				PageXMLWriter.saveDocument(pageXML, xmlName, bookdir);
 				break;
 			case "savedir":
-				String savedir = config.getSetting("savedir");
+				database = new FileDatabase(new File(fileManager.getLocalBooksPath()),
+						config.getListSetting("imagefilter"));
+
+				String savedir = fileManager.getSaveDir();
 				if (savedir != null && !savedir.equals("")) {
+					savedir = savedir + File.separator + database.getBookName(bookid);
 					PageXMLWriter.saveDocument(pageXML, xmlName, savedir);
 				} else {
 					System.err.println("Warning: Save dir is not set. File could not been saved.");

--- a/src/main/java/de/uniwue/web/controller/LibraryController.java
+++ b/src/main/java/de/uniwue/web/controller/LibraryController.java
@@ -44,8 +44,12 @@ public class LibraryController {
 		fileManager.init(servletContext);
 		config.read(new File(fileManager.getConfigurationFile()));
 		String bookFolder = config.getSetting("bookpath");
+    String saveDir = config.getSetting("savedir");
 		if (!bookFolder.equals("")) {
 			fileManager.setLocalBooksPath(bookFolder);
+		}
+		if (saveDir != null && !saveDir.equals("")) {
+			fileManager.setSaveDir(saveDir);
 		}
 		File bookPath = new File(fileManager.getLocalBooksPath());
 		bookPath.isDirectory();

--- a/src/main/java/de/uniwue/web/controller/SegmentationController.java
+++ b/src/main/java/de/uniwue/web/controller/SegmentationController.java
@@ -59,8 +59,12 @@ public class SegmentationController {
 		if (!config.isInitiated()) {
 			config.read(new File(fileManager.getConfigurationFile()));
 			String bookFolder = config.getSetting("bookpath");
+			String saveDir = config.getSetting("savedir");
 			if (!bookFolder.equals("")) {
 				fileManager.setLocalBooksPath(bookFolder);
+			}
+			if (saveDir != null && !saveDir.equals("")) {
+				fileManager.setSaveDir(saveDir);
 			}
 		}
 		this.segProgress = 0;

--- a/src/main/java/de/uniwue/web/controller/ViewerController.java
+++ b/src/main/java/de/uniwue/web/controller/ViewerController.java
@@ -49,8 +49,12 @@ public class ViewerController {
 		if (!config.isInitiated()) {
 			config.read(new File(fileManager.getConfigurationFile()));
 			String bookFolder = config.getSetting("bookpath");
+			String saveDir = config.getSetting("savedir");
 			if (!bookFolder.equals("")) {
 				fileManager.setLocalBooksPath(bookFolder);
+			}
+			if (saveDir != null && !saveDir.equals("")) {
+				fileManager.setSaveDir(saveDir);
 			}
 		}
 	}

--- a/src/main/java/de/uniwue/web/io/FilePathManager.java
+++ b/src/main/java/de/uniwue/web/io/FilePathManager.java
@@ -20,6 +20,7 @@ public class FilePathManager {
 	private boolean isInit = false;
 	private ServletContext servletContext;
 	private String booksPath;
+	private String saveDir;
 
 	/**
 	 * Init FileManager with servletContext in order to provide f
@@ -40,6 +41,15 @@ public class FilePathManager {
 	 */
 	public String getLocalBooksPath() {
 		return booksPath;
+	}
+
+	/**
+	 * Get the local disc path to the savedir
+	 *
+	 * @return disc path to the savedir
+	 */
+	public String getSaveDir() {
+		return saveDir;
 	}
 
 	/**
@@ -79,6 +89,15 @@ public class FilePathManager {
 	}
 
 	/**
+	 * Change the local disc savedir
+	 *
+	 * @param saveDir path the savedir is about to point to
+	 */
+	public void setSaveDir(String saveDir) {
+		this.saveDir = new File(saveDir).getAbsolutePath();
+	}
+
+	/**
 	 * Find the local disc path to a page image
 	 * 
 	 * @param page
@@ -96,7 +115,17 @@ public class FilePathManager {
 	 * @return
 	 */
 	public File getAnnotationPath(String bookname, String pagename) {
-		return new File(this.getLocalBooksPath() + File.separator + bookname + File.separator + pagename + ".xml");
+		File annotationPathBookPath = new File(this.getLocalBooksPath() + File.separator + bookname + File.separator + pagename + ".xml");
+		if (this.getSaveDir() != null) {
+			File annotationPathSaveDir = new File(this.getSaveDir() + File.separator + bookname + File.separator + pagename + ".xml");
+			if (annotationPathSaveDir.exists()) {
+				return annotationPathSaveDir;
+			} else {
+				return annotationPathBookPath;
+			}
+		} else {
+			return annotationPathBookPath;
+		}
 	}
 
 	/**

--- a/src/main/java/de/uniwue/web/io/PageXMLWriter.java
+++ b/src/main/java/de/uniwue/web/io/PageXMLWriter.java
@@ -185,14 +185,20 @@ public class PageXMLWriter {
 			if (!outputFolder.endsWith(File.separator)) 
 				outputFolder += File.separator;
 
+			File createdOutputFolder = new File(outputFolder);
+			if (createdOutputFolder.mkdir()) {
+				createdOutputFolder.setReadable(true, false);
+			}
+
 			final String outputPath = outputFolder + fileName;
 			
-
-			FileOutputStream output = new FileOutputStream(new File(outputPath));
+			File createdOutputPath = new File(outputPath);
+			FileOutputStream output = new FileOutputStream(createdOutputPath);
 			StreamResult result = new StreamResult(output);
 			transformer.transform(source, result);
 
 			output.close();
+			createdOutputPath.setReadable(true, false);
 
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
This change makes it possible not only to save updated XML files to a savedir, but also to load them back from the savedir when the page has been refreshed. This turns the savedir into an overlay read-write layer for the bookpath, which may be the prefered modus operandi if we'd like to keep the bookpath read-only, but also allow the users to change the annotations.

With more than one user, this change can produce race conditions, where a user may load an incomplete annotation from the savedir. Using advisory locking should solve this problem:

``` java
try (RandomAccessFile file = new RandomAccessFile(path, "rw");
      FileChannel channel = file.getChannel();
      FileLock lock = channel.lock()) {
    // write to the channel
}
```