### PR TITLE
Confidence View 

### DIFF
--- a/development/dev.properties
+++ b/development/dev.properties
@@ -64,12 +64,17 @@ websave=false
 # e.g. ocr4all:enable
 #ocr4all=<value>
 
-# Set Colors for DiffView in TextViewer mode
+# Set Colors for DiffView and ConfidenceView in TextViewer mode
 # This setting allows adjusting the colors for better contrast or better readability regarding color blindness.
 # All valid CSS colors are accepted.
 # e.g.:diff_insert_color=green
 #
 # Defaults: diff_insert_color=#58e123
 #           diff_delete_color=#e56123
+#           conf_above_color=#FFFFFF
+#           conf_below_color=#e56123
+#
 #diff_insert_color=<value>
 #diff_delete_color=<value>
+#conf_above_color=<value>
+#conf_below_color=<value>

--- a/src/main/java/de/uniwue/web/io/PageXMLReader.java
+++ b/src/main/java/de/uniwue/web/io/PageXMLReader.java
@@ -20,9 +20,11 @@ import org.primaresearch.dla.page.layout.physical.Region;
 import org.primaresearch.dla.page.layout.physical.impl.CustomRegion;
 import org.primaresearch.dla.page.layout.physical.impl.NoiseRegion;
 import org.primaresearch.dla.page.layout.physical.text.LowLevelTextObject;
+import org.primaresearch.dla.page.layout.physical.text.impl.Glyph;
 import org.primaresearch.dla.page.layout.physical.text.impl.TextContentVariants.TextContentVariant;
 import org.primaresearch.dla.page.layout.physical.text.impl.TextLine;
 import org.primaresearch.dla.page.layout.physical.text.impl.TextRegion;
+import org.primaresearch.dla.page.layout.physical.text.impl.Word;
 import org.primaresearch.dla.page.metadata.MetaData;
 import org.primaresearch.shared.variable.IntegerValue;
 import org.primaresearch.shared.variable.IntegerVariable;
@@ -118,6 +120,30 @@ public class PageXMLReader {
 							final TextLine textLine = (TextLine) text;
 							final String id = text.getId().toString();
 
+							//get Words of TextLine if they exist
+							final List<de.uniwue.web.model.Word> words = new ArrayList<>();
+							if(((TextLine) text).hasTextObjects()) {
+								for(int i = 0; i < ((TextLine) text).getTextObjectCount(); i++) {
+									Word primaWord =(Word) ((TextLine) text).getTextObject(i);
+
+									// get Glyphs of Word if they exist
+									final List<de.uniwue.web.model.Glyph> glyphs = new ArrayList<>();
+									for(int j = 0; j < primaWord.getTextObjectCount(); j++) {
+										Glyph primaGlyph = (Glyph) primaWord.getTextObject(j);
+										glyphs.add(new de.uniwue.web.model.Glyph(primaGlyph.getId().toString(),
+														new de.uniwue.web.model.Polygon(primaGlyph.getCoords()),
+														primaGlyph.getText(),
+														primaGlyph.getConfidence()));
+									}
+
+									words.add(new de.uniwue.web.model.Word(primaWord.getId().toString(),
+													new de.uniwue.web.model.Polygon(primaWord.getCoords()),
+													primaWord.getText(),
+													primaWord.getConfidence(),
+													glyphs));
+								}
+							}
+
 							// Get Coords of TextLine
 							de.uniwue.web.model.Polygon textlineCoords = new de.uniwue.web.model.Polygon(textLine.getCoords());
 
@@ -153,7 +179,7 @@ public class PageXMLReader {
 								}
 							}
 
-							textLines.put(id, new de.uniwue.web.model.TextLine(id, textlineCoords, content, textlineBaseline));
+							textLines.put(id, new de.uniwue.web.model.TextLine(id, textlineCoords, content, textlineBaseline, words));
 							readingOrder.add(id);
 						}
 

--- a/src/main/java/de/uniwue/web/model/Glyph.java
+++ b/src/main/java/de/uniwue/web/model/Glyph.java
@@ -38,7 +38,7 @@ public class Glyph  extends Element {
      *
      * @return
      */
-    public String getGlyph() {
+    public String getText() {
         return text;
     }
 }

--- a/src/main/java/de/uniwue/web/model/Glyph.java
+++ b/src/main/java/de/uniwue/web/model/Glyph.java
@@ -1,0 +1,44 @@
+package de.uniwue.web.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A representation of a Glyph that is parsed to the gui. Contains positional
+ * points and text content in UTF-8.
+ */
+public class Glyph  extends Element {
+    /**
+     * Text content of the Glyph. (UTF-8)
+     */
+    @JsonProperty("text")
+    protected String text;
+    @JsonProperty("conf")
+    protected double conf;
+
+    /**
+     * Base constructor for the parsing from a JSON object, with all included data.
+     *
+     * @param id         Unique identifier of the text line
+     * @param text       Text content inside the text line
+     * @param coords Polygon which represents the coordinates in which the textline is enclosed
+     */
+    @JsonCreator
+    public Glyph(@JsonProperty("id") String id,
+                 @JsonProperty("coords") Polygon coords,
+                 @JsonProperty("text") String text,
+                 @JsonProperty("conf") double conf) {
+        super(id, coords);
+        this.text = text;
+        this.conf = conf;
+    }
+
+    /**
+     * Text content of the Glyph.(UTF-8)
+     *
+     * @return
+     */
+    public String getGlyph() {
+        return text;
+    }
+}

--- a/src/main/java/de/uniwue/web/model/TextLine.java
+++ b/src/main/java/de/uniwue/web/model/TextLine.java
@@ -1,6 +1,7 @@
 package de.uniwue.web.model;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,6 +21,8 @@ public class TextLine extends Element {
 	protected Map<Integer, String> text;
 	@JsonProperty("baseline")
 	protected Polygon baseline;
+	@JsonProperty("words")
+	protected List<Word> words;
 
 	/**
 	 * Base constructor for the parsing from a JSON object, with all included data.
@@ -33,10 +36,12 @@ public class TextLine extends Element {
 	public TextLine(@JsonProperty("id") String id,
 					@JsonProperty("coords") Polygon coords,
 					@JsonProperty("text") Map<Integer, String> text,
-					@JsonProperty("baseline") Polygon baseline) {
+					@JsonProperty("baseline") Polygon baseline,
+					@JsonProperty("words") List<Word> words) {
 		super(id, coords);
 		this.text = text;
 		this.baseline = baseline;
+		this.words = words;
 	}
 
 	public TextLine(String id, Polygon coords, Map<Integer, String> text) {

--- a/src/main/java/de/uniwue/web/model/Word.java
+++ b/src/main/java/de/uniwue/web/model/Word.java
@@ -1,0 +1,45 @@
+package de.uniwue.web.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class Word extends Element{
+    /**
+     * Text content of the Word. (UTF-8)
+     */
+    @JsonProperty("text")
+    protected String text;
+    @JsonProperty("conf")
+    protected double conf;
+    @JsonProperty("glyphs")
+    protected List<Glyph> glyphs;
+
+    /**
+     * Base constructor for the parsing from a JSON object, with all included data.
+     *
+     * @param id         Unique identifier of the word
+     * @param text       Text content of word
+     * @param coords Polygon which represents the coordinates in which the word is enclosed
+     */
+    @JsonCreator
+    public Word(@JsonProperty("id") String id,
+                @JsonProperty("coords") Polygon coords,
+                @JsonProperty("text") String text,
+                @JsonProperty("conf") double conf,
+                @JsonProperty("glyphs") List<Glyph> glyphs) {
+        super(id, coords);
+        this.text = text;
+        this.conf = conf;
+        this.glyphs = glyphs;
+    }
+
+    /**
+     * Text content of the Word.(UTF-8)
+     *
+     * @return
+     */
+    public String getWord() {
+        return text;
+    }
+}

--- a/src/main/java/de/uniwue/web/model/Word.java
+++ b/src/main/java/de/uniwue/web/model/Word.java
@@ -39,7 +39,7 @@ public class Word extends Element{
      *
      * @return
      */
-    public String getWord() {
+    public String getText() {
         return text;
     }
 }

--- a/src/main/webapp/WEB-INF/tags/sidebarText.tag
+++ b/src/main/webapp/WEB-INF/tags/sidebarText.tag
@@ -62,9 +62,10 @@
 						<label for="displayConfidence">Show Confidence</label>
 					</div>
 					<div id="inputConfThresholdContainer" class="row textModeCheckboxRow" style="display: none">
-						<p class="settings-header settings-input">Threshold</p>
-						<p class="settings-input"><input value="0.90" id="confThreshold" class="input-number confThreshold" type="number" min="0" max="1" step ="0.01" class="validate" />
-							<label for="confThreshold">Threshold</label></p>
+						<div class="settings-input">
+							<label style="font-size: 15px;" for="confThreshold">Threshold</label>
+							<input value="0.90" id="confThreshold" class="input-number confThreshold" type="number" min="0" max="1" step ="0.01" class="validate" />
+							</div>
 					</div>
 					<div id="displayWordConfContainer" class="row textModeCheckboxRow  confViewChange" style="display: none">
 						<input name="confidenceGroup" type="radio" id="displayWordConf"/>
@@ -74,9 +75,9 @@
 						<input name="confidenceGroup" type="radio" id="displayGlyphConf"/>
 						<label for="displayGlyphConf">Glyph Confidence</label>
 					</div>
-					<div id="displayConfBelowContainer" class="row textModeCheckboxRow" style="display: none">
+					<div id="displayConfBelowContainer" class="row textModeCheckboxRow" style="display: none; margin-bottom: 15px !important;">
 						<input type="checkbox" id="displayConfBelow"/>
-						<label for="displayConfBelow">Only show below threshold</label>
+						<label for="displayConfBelow">Only show lines below threshold</label>
 					</div>
 				</div>
 			</div>

--- a/src/main/webapp/WEB-INF/tags/sidebarText.tag
+++ b/src/main/webapp/WEB-INF/tags/sidebarText.tag
@@ -53,9 +53,26 @@
 						<input type="checkbox" id="displayMismatch"/>
 						<label for="displayMismatch">Only show mismatching lines</label>
 					</div>
-					<div id="displayPredictionContainer" class="row textModeCheckboxRow" style="display: none">
+					<div id="displayPredictionContainer" class="row textModeCheckboxRow">
 						<input type="checkbox" id="displayPrediction"/>
 						<label for="displayPrediction">Show Prediction</label>
+					</div>
+					<div id="displayConfidenceContainer" class="row textModeCheckboxRow confViewChange" style="display: block">
+						<input type="checkbox" id="displayConfidence"/>
+						<label for="displayConfidence">Show Confidence</label>
+					</div>
+					<div id="inputConfThresholdContainer" class="row textModeCheckboxRow" style="display: none">
+						<p class="settings-header settings-input">Threshold</p>
+						<p class="settings-input"><input value="0.90" id="confThreshold" class="input-number confThreshold" type="number" min="0" max="1" step ="0.01" class="validate" />
+							<label for="confThreshold">Threshold</label></p>
+					</div>
+					<div id="displayWordConfContainer" class="row textModeCheckboxRow  confViewChange" style="display: none">
+						<input name="confidenceGroup" type="radio" id="displayWordConf"/>
+						<label for="displayWordConf">Word Confidence</label>
+					</div>
+					<div id="displayGlyphConfContainer" class="row textModeCheckboxRow  confViewChange" style="display: none">
+						<input name="confidenceGroup" type="radio" id="displayGlyphConf"/>
+						<label for="displayGlyphConf">Glyph Confidence</label>
 					</div>
 				</div>
 			</div>

--- a/src/main/webapp/WEB-INF/tags/sidebarText.tag
+++ b/src/main/webapp/WEB-INF/tags/sidebarText.tag
@@ -74,6 +74,10 @@
 						<input name="confidenceGroup" type="radio" id="displayGlyphConf"/>
 						<label for="displayGlyphConf">Glyph Confidence</label>
 					</div>
+					<div id="displayConfBelowContainer" class="row textModeCheckboxRow" style="display: none">
+						<input type="checkbox" id="displayConfBelow"/>
+						<label for="displayConfBelow">Only show below threshold</label>
+					</div>
 				</div>
 			</div>
 		</li>

--- a/src/main/webapp/WEB-INF/views/editor.jsp
+++ b/src/main/webapp/WEB-INF/views/editor.jsp
@@ -56,7 +56,9 @@
 		let globalSettings ={
 			downloadPage:${globalSettings.getSetting("websave").equals("") ? true : globalSettings.getSetting("websave")},
 			diff_insert_color:"${globalSettings.getSetting("diff_insert_color")}",
-			diff_delete_color:"${globalSettings.getSetting("diff_delete_color")}"
+			diff_delete_color:"${globalSettings.getSetting("diff_delete_color")}",
+			conf_above_color:"${globalSettings.getSetting("conf_above_color")}",
+			conf_below_color:"${globalSettings.getSetting("conf_below_color")}"
 		}
 
 		//specify specific colors

--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -2358,4 +2358,15 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		}
 		return JSON.stringify(obj) === JSON.stringify({});
 	}
+
+	/** TextViewer
+	 * Updates prediction according to confidence settings
+	 *
+	 */
+	this.confViewChange = function(){
+		$(".textline-container").each(function () {
+			let id = $(this).attr('data-id');
+			controller.updateTextLine(id);
+		});
+	}
 }

--- a/src/main/webapp/resources/js/viewer/guiInput.js
+++ b/src/main/webapp/resources/js/viewer/guiInput.js
@@ -522,6 +522,9 @@ function GuiInput(navigationController, controller, gui, textViewer, selector, c
 	$("#confThreshold").change(function(){
 		_controller.confViewChange();
 	})
+	$("#displayConfBelow").click(function(){
+		_textViewer._displayOnlyBelowThreshold();
+	})
 
 	$("#toggleSegmentVisibility").change(function () {
 		if(this.checked){

--- a/src/main/webapp/resources/js/viewer/guiInput.js
+++ b/src/main/webapp/resources/js/viewer/guiInput.js
@@ -513,6 +513,15 @@ function GuiInput(navigationController, controller, gui, textViewer, selector, c
 	$("#displayMismatch").click(function(){
 		_textViewer._displayOnlyMismatch();
 	})
+	$(".confViewChange").click(function(){
+		_controller.confViewChange();
+	})
+	$("#displayConfidence").change(function(){
+		_textViewer._toggleConfSettings();
+	})
+	$("#confThreshold").change(function(){
+		_controller.confViewChange();
+	})
 
 	$("#toggleSegmentVisibility").change(function () {
 		if(this.checked){

--- a/src/main/webapp/resources/js/viewer/textViewer.js
+++ b/src/main/webapp/resources/js/viewer/textViewer.js
@@ -492,12 +492,13 @@ class TextViewer {
 	 */
 	_markUpConfidence(text,confidence, threshold, useGradient){
 		//temporarily use insert/delete colors
-		let aboveColor = globalSettings.diff_insert_color;
-		let belowColor = globalSettings.diff_delete_color;
-		if(aboveColor == "" || !this._validColor(aboveColor)) {aboveColor = "#58e123";}
+		let aboveColor = globalSettings.conf_above_color;
+		let belowColor = globalSettings.conf_below_color;
+		if(aboveColor == "" || !this._validColor(aboveColor)) {aboveColor = "#FFFFFF";}
 		if(belowColor == "" || !this._validColor(belowColor)) {belowColor = "#e56123";}
 		let html;
 		if(confidence > threshold) {
+			if(aboveColor == "#FFFFFF") { return text;}
 			return '<span style="background:' + aboveColor + ';">' + text + '</span>';
 		} else {
 			return '<span style="background:' + belowColor + ';">' + text + '</span>';


### PR DESCRIPTION
This Pull Request adds the ability to indicate if a `conf` value of `Word` and `Glyph` elements is below a certain configurable confidence threshold. Confidence values for PageXML have been added in [version 2.1.4](https://github.com/Calamari-OCR/calamari/releases/tag/v2.1.4) of [calamari-ocr](https://github.com/Calamari-OCR).

- Confidence View of Glyphs:
![image](https://user-images.githubusercontent.com/51399945/137460517-c1ba8af3-acdd-4c5c-8994-593a5136adfb.png)

- Confidence View of Words:
![image](https://user-images.githubusercontent.com/51399945/137460652-a28a3c77-5a52-4ad3-9670-81a31eb5614c.png)

- Confidence View of Glyphs with DiffView shown:
![image](https://user-images.githubusercontent.com/51399945/137461262-16e96409-5190-4a58-98b1-2c466199acd5.png)

- Settings Tab Full Extended:
![image](https://user-images.githubusercontent.com/51399945/137461395-cc3681fc-53ee-4182-b7b6-36a949da24c9.png)
