### PR TITLE
add simplification for region polygons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,12 @@
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.locationtech.jts/jts-core -->
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <version>1.18.2</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/de/uniwue/web/controller/ImageProcessingController.java
+++ b/src/main/java/de/uniwue/web/controller/ImageProcessingController.java
@@ -1,9 +1,13 @@
 package de.uniwue.web.controller;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
@@ -77,5 +81,19 @@ public class ImageProcessingController {
 	@RequestMapping(value = "process/polygons/minarearect", method = RequestMethod.POST)
 	public @ResponseBody Rectangle getMinAreaRect(@RequestBody Polygon polygon) {
 		return ImageProcessingFacade.getMinAreaRectangle(polygon);
+	}
+
+	/**
+	 * Simplify Region Polygons
+	 *
+	 * @param segmentString Json string containing a list of regions
+	 * @param tolerance tolerance to be used when simplifying
+	 * @return list with simplified regions
+	 */
+	@RequestMapping(value = "process/regions/simplify", method = RequestMethod.POST, headers = "Accept=*/*")
+	public @ResponseBody List<Region> simplify(@RequestParam("segments") String segmentString, @RequestParam("tolerance") int tolerance) throws JsonProcessingException {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+		return ImageProcessingFacade.simplify(Arrays.asList(mapper.readValue(segmentString,Region[].class)), tolerance);
 	}
 }

--- a/src/main/java/de/uniwue/web/model/Element.java
+++ b/src/main/java/de/uniwue/web/model/Element.java
@@ -1,8 +1,9 @@
 package de.uniwue.web.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Element {
     @JsonProperty("id")
     protected String id;
@@ -36,6 +37,10 @@ public class Element {
 
     public Polygon getCoords(){
         return coords;
+    }
+
+    public void setCoords(Polygon coords){
+        this.coords = coords;
     }
 
     public String getParent(){

--- a/src/main/java/de/uniwue/web/model/Polygon.java
+++ b/src/main/java/de/uniwue/web/model/Polygon.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import de.uniwue.algorithm.geometry.PointList;
 
@@ -14,6 +15,7 @@ import de.uniwue.algorithm.geometry.PointList;
  * positioned via percentage (e.g. 0.1:0.1 -> 10%:10%)
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Polygon {
 
 	@JsonProperty("points")

--- a/src/main/webapp/WEB-INF/tags/sidebarSegmentation.tag
+++ b/src/main/webapp/WEB-INF/tags/sidebarSegmentation.tag
@@ -181,6 +181,13 @@
 						</label>
 					</span>
 				</div>
+				<div class="simplifyPolygonSettings row">
+					<a class="col s10 offset-s1 waves-effect waves-light btn simplifyPolygon segment-only tooltipped" data-position="bottom" data-delay="50" data-tooltip="Simplify selected polygon(s)">Simplify Polygon</a>
+					<div class="settings-input col s10 offset-s1 ">
+						<label style="font-size: 15px;" for="simplifyTolerance">Tolerance</label>
+						<input value="5" id="simplifyTolerance" class="input-number confThreshold" type="number" min="0" step="1" class="validate" />
+					</div>
+				</div>
 			</div>
 		</li>
 	</ul>

--- a/src/main/webapp/WEB-INF/tags/sidebarSegmentation.tag
+++ b/src/main/webapp/WEB-INF/tags/sidebarSegmentation.tag
@@ -181,6 +181,7 @@
 						</label>
 					</span>
 				</div>
+				<div class="divider row"></div>
 				<div class="simplifyPolygonSettings row">
 					<a class="col s10 offset-s1 waves-effect waves-light btn simplifyPolygon segment-only tooltipped" data-position="bottom" data-delay="50" data-tooltip="Simplify selected polygon(s)">Simplify Polygon</a>
 					<div class="settings-input col s10 offset-s1 ">

--- a/src/main/webapp/resources/js/viewer/communicator.js
+++ b/src/main/webapp/resources/js/viewer/communicator.js
@@ -108,6 +108,10 @@ class Communicator {
 		return this.request("process/regions/merge", segments, DataType.JSON);
 	}
 
+	simplify(segments, tolerance) {
+		return this.request("process/regions/simplify", {segments:JSON.stringify(segments), tolerance:tolerance});
+	}
+
 	extractContours(pageid, bookid) {
 		return this.request("process/contours/extract", {pageid:pageid,bookid:bookid});
 	}

--- a/src/main/webapp/resources/js/viewer/controller.js
+++ b/src/main/webapp/resources/js/viewer/controller.js
@@ -1186,6 +1186,40 @@ function Controller(bookID, accessible_modes, canvasID, regionColors, colors, gl
 		}
 	}
 
+	this.simplifySelectedPolygon = function (){
+		const selected = _selector.getSelectedSegments();
+		const selectType = _selector.getSelectedPolygonType();
+		const tolerance = parseInt($("#simplifyTolerance").val());
+
+		if(selected.length > 0 && (selectType === ElementType.SEGMENT || selectType === ElementType.TEXTLINE)){
+			const segments = [];
+			for (let i = 0, selectedlength = selected.length; i < selectedlength; i++) {
+				let segment = null;
+				if (selectType === ElementType.SEGMENT) {
+					segment = _segmentation[_currentPage].segments[selected[i]];
+				} else {
+					segment = _segmentation[_currentPage].segments[this.textlineRegister[selected[i]]].textlines[selected[i]];
+				}
+				segments.push(segment);
+			}
+			if (segments.length > 0) {
+				_communicator.simplify(segments, tolerance).done((data) => {
+					const simplified = data;
+					if(Array.isArray(simplified) && simplified.length > 0){
+						for (let i = 0, simplifiedLength = simplified.length; i < simplifiedLength; i++) {
+							let simp_id = simplified[i].id;
+							let simp_coords = simplified[i].coords;
+							_segmentation[_currentPage].segments[simp_id].coords = simp_coords;
+							_editor.updateSegment(simplified[i]);
+						}
+					} else {
+						_gui.displayWarning("Simplification of segments returned no segments.");
+					}
+				});
+			}
+		}
+	}
+
 	this.mergeSelected = function () {
 		const selected = _selector.getSelectedSegments();
 		const selectType = _selector.getSelectedPolygonType();

--- a/src/main/webapp/resources/js/viewer/guiInput.js
+++ b/src/main/webapp/resources/js/viewer/guiInput.js
@@ -102,6 +102,7 @@ function GuiInput(navigationController, controller, gui, textViewer, selector, c
 
 	$('.combineSelected').click(() => _controller.mergeSelected());
 	$('.deleteSelected').click(() => _controller.deleteSelected());
+	$('.simplifyPolygon').click(() => _controller.simplifySelectedPolygon());
 	$('.fixSelected').click(() => _controller.fixSelected());
 	$('.editContours').click(() => _controller.displayContours());
 	$('.move').click(() => _controller.move());


### PR DESCRIPTION
This Pull Request adds the ability to simplify selected region polygons shown in the editor using the [Topology preserving Simplifier](https://github.com/locationtech/jts/blob/master/modules/core/src/main/java/org/locationtech/jts/simplify/TopologyPreservingSimplifier.java) from the [JTS Toplogy Suite](https://github.com/locationtech/jts).
The function is available in the `SEGMENTS` sidebar trough `Actions` with `tolerance=5` as default.

- Larex Test Page: unsiimplified to `tolerance=8`:
![tolerance_demo](https://user-images.githubusercontent.com/51399945/141281735-147c840c-9363-4b8e-98c4-44fae811eec9.png)

- Unsimplified vs `tolerance = 10`:
![unsimp_simp10](https://user-images.githubusercontent.com/51399945/141281834-41a16de9-4830-4d36-bc45-23db2b06f4b1.png)


closes #286 
 