### PR TITLE
Feature fix/whitespace confidence

### DIFF
--- a/src/main/webapp/resources/js/viewer/guiInput.js
+++ b/src/main/webapp/resources/js/viewer/guiInput.js
@@ -531,7 +531,11 @@ function GuiInput(navigationController, controller, gui, textViewer, selector, c
 	})
 	$("div").on("click", ".glyph-option", function(){
 		let text = $(this).text()
-		if(text == '⌴') {text = ' ';}
+		if(text == '⌴') {
+			text = ' ';
+		} else if(text == _textViewer.blankCharacter) {
+			text = '';
+		}
 		_textViewer._copyTextToClipboard(text);
 	})
 

--- a/src/main/webapp/resources/js/viewer/guiInput.js
+++ b/src/main/webapp/resources/js/viewer/guiInput.js
@@ -524,10 +524,10 @@ function GuiInput(navigationController, controller, gui, textViewer, selector, c
 		_textViewer._toggleConfSettings();
 	})
 	$("#confThreshold1").change(function(){
-		_controller.confViewChange();
+		typewatch(function (){_controller.confViewChange();},500);
 	})
 	$("#confThreshold2").change(function(){
-		_controller.confViewChange();
+		typewatch(function (){_controller.confViewChange();},500);
 	})
 	$("div").on("click", ".glyph-option", function(){
 		let text = $(this).text()
@@ -562,4 +562,12 @@ function GuiInput(navigationController, controller, gui, textViewer, selector, c
 	$('#showShortcuts').click(() => _controller.toggleShortcutModal());
 	$("#metadata-save").click(() => _controller.saveMetadata());
 	$("#openFullscreen").click(() => _gui.toggleFullscreen());
+
+	let typewatch = function(){
+		let timer = 0;
+		return function(callback, ms){
+			clearTimeout (timer);
+			timer = setTimeout(callback, ms);
+		}
+	}();
 }

--- a/src/main/webapp/resources/js/viewer/guiInput.js
+++ b/src/main/webapp/resources/js/viewer/guiInput.js
@@ -530,7 +530,9 @@ function GuiInput(navigationController, controller, gui, textViewer, selector, c
 		_controller.confViewChange();
 	})
 	$("div").on("click", ".glyph-option", function(){
-		_textViewer._copyTextToClipboard($(this).text());
+		let text = $(this).text()
+		if(text == '⌴') {text = ' ';}
+		_textViewer._copyTextToClipboard(text);
 	})
 
 	$("#toggleSegmentVisibility").change(function () {

--- a/src/main/webapp/resources/js/viewer/textViewer.js
+++ b/src/main/webapp/resources/js/viewer/textViewer.js
@@ -5,6 +5,7 @@
 class TextViewer {
 	constructor(viewerInput) {
 		this.root = $("#viewerText");
+		this.blankCharacter = '🞍';
 		this.container = $("#viewerTextContainer");
 		this.thisInput = viewerInput;
 		this.image;
@@ -518,11 +519,15 @@ class TextViewer {
 		if(belowColor == "" || !this._validColor(belowColor)) {belowColor = "#e56123";}
 		let html;
 		if(confidence > threshold) {
-			if(text == ' ') {text = '';}
+			//if(text == ' ') {text = '';}
 			if(aboveColor == "#FFFFFF") { return text;}
 			return '<span style="background:' + aboveColor + ';">' + text + '</span>';
 		} else {
-			if(text == ' ') {text = '⌴';}
+			if(text == ' ') {
+				text = '⌴';
+			} else if(text == '' || text == null) {
+				text = this.blankCharacter;
+			}
 			return '<span style="background:' + belowColor + ';">' + text + '</span>';
 		}
 	}
@@ -540,7 +545,6 @@ class TextViewer {
 		if(belowT2Color == "" || !this._validColor(belowT2Color)) {belowT2Color = "#e5c223";}
 
 		let text = glyphVariants[0].text;
-		if(text == ' ') {text = '⌴';}
 		let confidence = glyphVariants[0].conf;
 		let hasValidVariant = false;
 		if(threshold2 > 0.0 && glyphVariants.length > 1) {
@@ -556,8 +560,17 @@ class TextViewer {
 				let variantHtml = "";
 				for (let variantGlyph of validGlyphList) {
 					let variantGlyphText = variantGlyph.text;
-					if(variantGlyphText == ' ') {variantGlyphText = '⌴';}
-					variantHtml = variantHtml + '<option class="glyph-option">' + variantGlyph.text + '</option>';
+					if(variantGlyphText == ' ') {
+						variantGlyphText = '⌴';
+					} else if(variantGlyphText == '' || variantGlyphText == null) {
+						variantGlyphText = this.blankCharacter;
+					}
+					variantHtml = variantHtml + '<option class="glyph-option">' + variantGlyphText + '</option>';
+				}
+				if(text == ' ') {
+					text = '⌴';
+				} else if(text == '' || text == null) {
+					text = this.blankCharacter;
 				}
 				text = '<span></span><select class="glyph-select" style="background:' + belowT2Color + ';"><option class="glyph-option">' + text + '</option>' + variantHtml + '</select></span>';
 				return [text,hasValidVariant];
@@ -773,7 +786,11 @@ class TextViewer {
 	_copyTextToClipboard(text) {
 		navigator.clipboard.writeText(text).then(function() {
 			console.log('Async: Copying to clipboard was successful!');
-			if(text = ' ') {text = '⌴';}
+			if(text == ' ') {
+				text = '⌴';
+			} else if(text == '' || text == null ) {
+				text = this.blankCharacter;
+			}
 			let toastMsg = text + " copied to clipboard!";
 			Materialize.toast(toastMsg, 4000, "green");
 			// handle old materialize bug where multiple toasts are displayed

--- a/src/main/webapp/resources/js/viewer/textViewer.js
+++ b/src/main/webapp/resources/js/viewer/textViewer.js
@@ -495,7 +495,8 @@ class TextViewer {
 			}
 			pred_text = wordList.join(' ');
 		}
-
+		//replace multiple whitespaces
+		pred_text = pred_text.replace( /  +/g, ' ' );
 		return [pred_text,minConf,hasValidVariants];
 	}
 	/**
@@ -515,9 +516,11 @@ class TextViewer {
 		if(belowColor == "" || !this._validColor(belowColor)) {belowColor = "#e56123";}
 		let html;
 		if(confidence > threshold) {
+			if(text == ' ') {text = '';}
 			if(aboveColor == "#FFFFFF") { return text;}
 			return '<span style="background:' + aboveColor + ';">' + text + '</span>';
 		} else {
+			if(text == ' ') {text = '⌴';}
 			return '<span style="background:' + belowColor + ';">' + text + '</span>';
 		}
 	}
@@ -535,6 +538,7 @@ class TextViewer {
 		if(belowT2Color == "" || !this._validColor(belowT2Color)) {belowT2Color = "#e5c223";}
 
 		let text = glyphVariants[0].text;
+		if(text == ' ') {text = '⌴';}
 		let confidence = glyphVariants[0].conf;
 		let hasValidVariant = false;
 		if(threshold2 > 0.0 && glyphVariants.length > 1) {
@@ -549,6 +553,8 @@ class TextViewer {
 			if(validGlyphList.length > 0) {
 				let variantHtml = "";
 				for (let variantGlyph of validGlyphList) {
+					let variantGlyphText = variantGlyph.text;
+					if(variantGlyphText == ' ') {variantGlyphText = '⌴';}
 					variantHtml = variantHtml + '<option class="glyph-option">' + variantGlyph.text + '</option>';
 				}
 				text = '<span></span><select class="glyph-select" style="background:' + belowT2Color + ';"><option class="glyph-option">' + text + '</option>' + variantHtml + '</select></span>';
@@ -765,6 +771,7 @@ class TextViewer {
 	_copyTextToClipboard(text) {
 		navigator.clipboard.writeText(text).then(function() {
 			console.log('Async: Copying to clipboard was successful!');
+			if(text = ' ') {text = '⌴';}
 			let toastMsg = text + " copied to clipboard!";
 			Materialize.toast(toastMsg, 4000, "green");
 			// handle old materialize bug where multiple toasts are displayed


### PR DESCRIPTION
This Pull Request adds the ability to handle whitespaces (`U+0020`) in Textviewer confidence view:

- Each whitespace will be represented as `⌴` only when it has been flagged above or below the tresholds.
- Copying the character to clipboard will of course copy the true whitespace (`U+0020`) character and not its replacement (`⌴`). 
- Blank Words and Glyphs are now represented by `🞍` (Black Slightly Small Square; U+1F78D).
- A timeout has been added to the threshold inputs to inhibit calculating the ouput on every increment.