### PR TITLE
fix/textline reading order

### DIFF
--- a/src/main/java/de/uniwue/web/io/PageXMLReader.java
+++ b/src/main/java/de/uniwue/web/io/PageXMLReader.java
@@ -18,8 +18,7 @@ import org.primaresearch.dla.page.layout.logical.RegionRef;
 import org.primaresearch.dla.page.layout.physical.Region;
 import org.primaresearch.dla.page.layout.physical.impl.CustomRegion;
 import org.primaresearch.dla.page.layout.physical.impl.NoiseRegion;
-import org.primaresearch.dla.page.layout.physical.text.LowLevelTextObject;
-import org.primaresearch.dla.page.layout.physical.text.graphemes.GraphemeElement;
+import org.primaresearch.dla.page.layout.physical.text.TextObject;
 import org.primaresearch.dla.page.layout.physical.text.impl.Glyph;
 import org.primaresearch.dla.page.layout.physical.text.impl.TextContentVariants.TextContentVariant;
 import org.primaresearch.dla.page.layout.physical.text.impl.TextLine;
@@ -112,10 +111,11 @@ public class PageXMLReader {
 						subtype = TypeConverter.stringToSubType(textRegion.getTextType());
 					}
 					// Extract Text
-					for (LowLevelTextObject text : textRegion.getTextObjectsSorted()) {
+					for(int n = 0; n < textRegion.getTextObjectCount(); n++){
+						TextObject text = textRegion.getTextObject(n);
 						if (text instanceof TextLine) {
 							final TextLine textLine = (TextLine) text;
-							final String id = text.getId().toString();
+							final String id = textLine.getId().toString();
 
 							//get Words of TextLine if they exist
 							final List<de.uniwue.web.model.Word> words = new ArrayList<>();

--- a/src/main/java/de/uniwue/web/io/PageXMLWriter.java
+++ b/src/main/java/de/uniwue/web/io/PageXMLWriter.java
@@ -290,9 +290,31 @@ public class PageXMLWriter {
 							textContent.getAttributes().add(new IntegerVariable("index", new IntegerValue(index)));
 						}
 					}else{
-						createTextLine(textLine, textRegion);
+						createTextLine(textLine, textRegion, element);
 					}
 				}
+
+				// Update TextLine reading order
+				// This process is necessary as there isn't a standard convention for setting the TextLine reading order
+				// via the PAGE schema and the reading order is therefore determined by the physical order in the XML
+				// file.
+				Map<String, TextLine> updatedPhysicalTextLines = getTextLines(textRegion);
+				for (Entry<String, TextLine> lineEntry : getTextLines(textRegion).entrySet()) {
+					textRegion.removeTextObject(lineEntry.getValue().getId());
+				}
+				if(element.getReadingOrder() != null) {
+					System.out.println(element.getReadingOrder());
+					List<String> readingOrder = element.getReadingOrder();
+					for (String _id : readingOrder){
+						textRegion.addTextObject(updatedPhysicalTextLines.get(_id));
+						updatedPhysicalTextLines.remove(_id);
+					}
+				}
+				for (TextLine unindexedTextLine : updatedPhysicalTextLines.values()){
+					textRegion.addTextObject(unindexedTextLine);
+				}
+
+
 			}else if(!physicalRegion.getType().toString().equals(elementType)){
 				// Deletes region as it well created with the new type in the following step
 				// Todo: This should be changed to e.g. allow passing existing attributes (in case they're still allowed
@@ -310,8 +332,15 @@ public class PageXMLWriter {
 	 * @param textline
 	 * @param textRegion
 	 */
-	private static void createTextLine(de.uniwue.web.model.TextLine textline, TextRegion textRegion){
+	private static void createTextLine(de.uniwue.web.model.TextLine textline,
+									   TextRegion textRegion,
+									   de.uniwue.web.model.Region regionSegment){
 		final TextLine pageTextLine = textRegion.createTextLine();
+		List<String> textLineReadingOrder = regionSegment.getReadingOrder();
+		Collections.replaceAll(textLineReadingOrder,
+				textline.getId(),
+				pageTextLine.getId().toString());
+		regionSegment.setReadingOrder(textLineReadingOrder);
 
 		final Polygon coords = new Polygon();
 		for (Point point : textline.getCoords().getPoints()) {
@@ -341,7 +370,6 @@ public class PageXMLWriter {
 			if(textObject instanceof TextLine) {
 				TextLine _textLine = (TextLine) textObject;
 				String _id = _textLine.getId().toString();
-
 				physicalTextLines.put(_id, _textLine);
 			}
 		}
@@ -377,7 +405,6 @@ public class PageXMLWriter {
 			if(type.getSubtype() != null) {
 				textRegion.setTextType(TypeConverter.subTypeToString(type.getSubtype()));
 			}
-
 			// Add TextLines if existing
 			if(regionSegment.getTextlines() != null) {
 				final List<de.uniwue.web.model.TextLine> textlines = new ArrayList<>(regionSegment.getTextlines().values());
@@ -395,7 +422,7 @@ public class PageXMLWriter {
 
 				// Iterate over sorted text lines and add to PAGE XML
 				for (de.uniwue.web.model.TextLine textline : textlines) {
-					createTextLine(textline, textRegion);
+					createTextLine(textline, textRegion, regionSegment);
 				}
 			}
 		}

--- a/src/main/java/de/uniwue/web/io/PageXMLWriter.java
+++ b/src/main/java/de/uniwue/web/io/PageXMLWriter.java
@@ -303,7 +303,6 @@ public class PageXMLWriter {
 					textRegion.removeTextObject(lineEntry.getValue().getId());
 				}
 				if(element.getReadingOrder() != null) {
-					System.out.println(element.getReadingOrder());
 					List<String> readingOrder = element.getReadingOrder();
 					for (String _id : readingOrder){
 						textRegion.addTextObject(updatedPhysicalTextLines.get(_id));

--- a/src/main/java/de/uniwue/web/model/Region.java
+++ b/src/main/java/de/uniwue/web/model/Region.java
@@ -31,7 +31,7 @@ public class Region extends Element{
 	@JsonProperty("textlines")
 	protected final Map<String,TextLine> textlines;
 	@JsonProperty("readingOrder")
-	protected final List<String> readingOrder;
+	protected List<String> readingOrder;
 
 	@JsonCreator
 	public Region(@JsonProperty("id") String id, @JsonProperty("type") String type,
@@ -88,5 +88,13 @@ public class Region extends Element{
 	 */
 	public List<String> getReadingOrder() {
 		return readingOrder;
+	}
+
+	/**
+	 * Update the reading order of the contained textlines
+	 * @param readingOrder
+	 */
+	public void setReadingOrder(List<String> readingOrder) {
+		this.readingOrder = readingOrder;
 	}
 }

--- a/src/main/webapp/resources/js/viewer/actions.js
+++ b/src/main/webapp/resources/js/viewer/actions.js
@@ -854,7 +854,12 @@ function ActionAddTextLineToReadingOrder(id, parentID, page, segmentation, contr
 			_isExecuted = true;
 
 			if (!_oldReadingOrder) {
-				_oldReadingOrder = JSON.parse(JSON.stringify(segmentation[page].segments[parentID].readingOrder));
+				if(segmentation[page].segments[parentID].readingOrder){
+					_oldReadingOrder = JSON.parse(JSON.stringify(segmentation[page].segments[parentID].readingOrder));
+				}else{
+					_oldReadingOrder = JSON.parse(JSON.stringify([]));
+				}
+
 			}
 
 			if (!_newReadingOrder) {


### PR DESCRIPTION
Fixes a bug which stopped changes to the TextLine reading order getting carried over to the XML file after we switched from always creating a new XML file to merging results into existing XML files.

Also fixes another bug which didn't allow manually setting the TextLine reading order on newly created regions. 