### PR TITLE
Feat Don't log to stderr / stdout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.uniwue</groupId>
@@ -16,6 +17,8 @@
         <java.version>1.8</java.version>
         <spring.version>5.2.22.RELEASE</spring.version>
         <cglib.version>3.2.8</cglib.version>
+        <logback.version>1.5.6</logback.version>
+        <log.sl4j.version>2.1.0-alpha1</log.sl4j.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
     </properties>
 
@@ -58,6 +61,19 @@
             <type>jar</type>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${log.sl4j.version}</version>
+        </dependency>
+        
 
         <!-- Java Advanced Imaging (JAI) Image I/O Tools -->
         <dependency>

--- a/src/main/java/de/uniwue/web/config/LarexConfiguration.java
+++ b/src/main/java/de/uniwue/web/config/LarexConfiguration.java
@@ -3,6 +3,8 @@ package de.uniwue.web.config;
 import java.io.*;
 import java.util.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +17,9 @@ import org.springframework.stereotype.Component;
 @Scope("session")
 public class LarexConfiguration {
 
+
+	static Logger logger = LoggerFactory.getLogger(LarexConfiguration.class);
+	private String configurationFile;
 	private Map<String, String> configurations;
 
 	/**
@@ -26,6 +31,7 @@ public class LarexConfiguration {
 	public void read(File configuration) {
 		configurations = new HashMap<>();
 		try {
+			this.configurationFile = configuration.getAbsolutePath();
 			FileReader input = new FileReader(configuration);
 			Properties prop = new Properties();
 			prop.load(input);
@@ -49,7 +55,7 @@ public class LarexConfiguration {
 	 */
 	public String getSetting(String setting) {
 		if (!isInitiated()) {
-			System.err.println("Configuration file has not been read.");
+			logger.error("Configuration {} has not been read, return empty String", this.configurationFile);
 			return "";
 		}
 		return configurations.getOrDefault(setting, "");
@@ -64,7 +70,7 @@ public class LarexConfiguration {
 	 */
 	public List<String> getListSetting(String setting) {
 		if (!isInitiated()) {
-			System.err.println("Configuration file has not been read.");
+			logger.error("Configuration {} has not been read, return empty List", this.configurationFile);
 			return new ArrayList<>();
 		}
 		if (configurations.containsKey(setting)) {
@@ -83,7 +89,7 @@ public class LarexConfiguration {
 	 */
 	public void setSetting(String setting, String value) {
 		if (!isInitiated()) {
-			System.err.println("Configuration file has not been read.");
+			logger.error("Configuration {} has not been read, set empty Map", this.configurationFile);
 			this.configurations = new HashMap<String, String>();
 		}
 		configurations.put(setting, value);

--- a/src/main/java/de/uniwue/web/controller/FileController.java
+++ b/src/main/java/de/uniwue/web/controller/FileController.java
@@ -26,6 +26,8 @@ import org.opencv.core.MatOfByte;
 import org.opencv.core.Size;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.imgproc.Imgproc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpHeaders;
@@ -62,6 +64,9 @@ import de.uniwue.web.model.PageAnnotations;
 @Controller
 @Scope("session")
 public class FileController {
+
+	static Logger logger = LoggerFactory.getLogger(FileController.class);
+
 	@Autowired
 	private ServletContext servletContext;
 	@Autowired
@@ -406,7 +411,8 @@ public class FileController {
 						if(!savedir.endsWith(File.separator)) { savedir += File.separator; }
 						return new File(savedir + xmlName);
 					} else {
-						System.err.println("Warning: Save dir is not set. File could not been saved.");
+						logger.error("Warning: Save dir {} not set. File {} could not been saved.", 
+						savedir, xmlName);
 					}
 				} else {
 					return new File(fileManager.getLocalXmlMap().get(xmlName.split("\\.")[0]));

--- a/src/main/java/de/uniwue/web/controller/LibraryController.java
+++ b/src/main/java/de/uniwue/web/controller/LibraryController.java
@@ -35,6 +35,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Scope("request")
 public class LibraryController {
 
+	public static final String ENV_LAREX_VERSION = "LAREX_VERSION";
+
 	static Logger logger = LoggerFactory.getLogger(LibraryController.class);
 
 	@Autowired
@@ -231,14 +233,11 @@ public class LibraryController {
 	@RequestMapping(value ="library/getVersion" , method = RequestMethod.GET)
 	public @ResponseBody
 	String getVersion() {
-		logger.info("request LAREX_VERSION");
-		String larexVersion = "";
-		try {
-			larexVersion = System.getenv("LAREX_VERSION");
-			logger.info("request LAREX_VERSION: {}", larexVersion);
-		} catch (Exception e) {
-			logger.error("Unable to determine LAREX_VERSION: {}", e.getMessage());
+		String larexVersion = System.getenv(ENV_LAREX_VERSION);
+		if (larexVersion == null) {
+			logger.warn("LAREX_VERSION unset in Env");
+			larexVersion = "";
 		}
-		return larexVersion.equals("") ? "UNKNOWN" : larexVersion;
+		return "".equals(larexVersion) ? "UNKNOWN" : larexVersion;
 	}
 }

--- a/src/main/java/de/uniwue/web/controller/LibraryController.java
+++ b/src/main/java/de/uniwue/web/controller/LibraryController.java
@@ -88,7 +88,7 @@ public class LibraryController {
 		}
 		File bookPath = new File(fileManager.getLocalBooksPath());
 		if (!bookPath.isDirectory()) {
-			logger.error("Specified bookpath {} no directory, Please set a valid bookpath in larex.properties!",
+			logger.error("Specified bookpath {} not a directory. Please set a valid bookpath in larex.properties!",
 			bookPath);
 			return "redirect:/500";
 		}
@@ -129,7 +129,7 @@ public class LibraryController {
 				case "flat":
 					return getFileMap(baseFolder.getAbsolutePath(), Constants.IMG_EXTENSIONS_DOTTED);
 				default:
-					logger.error("Attempt open empty directory {}", baseFolder.getAbsolutePath());
+					logger.error("Attempt opening empty directory {}", baseFolder.getAbsolutePath());
 					break;
 			}
 		} catch (Exception e) {
@@ -173,7 +173,7 @@ public class LibraryController {
 	public @ResponseBody DirectRequest getOldRequest() {
 		DirectRequest directRequest = this.fileManager.getDirectRequest();
 		if (directRequest != null) {
-			logger.info("pass last {}", directRequest.getMetsPath());
+			logger.info("Pass last {}", directRequest.getMetsPath());
 		}
 		return directRequest;
 	}

--- a/src/main/java/de/uniwue/web/controller/LibraryController.java
+++ b/src/main/java/de/uniwue/web/controller/LibraryController.java
@@ -10,6 +10,9 @@ import javax.servlet.ServletContext;
 import de.uniwue.web.communication.DirectRequest;
 import de.uniwue.web.config.Constants;
 import de.uniwue.web.io.MetsReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
@@ -31,6 +34,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Controller
 @Scope("request")
 public class LibraryController {
+
+	static Logger logger = LoggerFactory.getLogger(LibraryController.class);
+
 	@Autowired
 	private ServletContext servletContext;
 	@Autowired
@@ -80,8 +86,8 @@ public class LibraryController {
 		}
 		File bookPath = new File(fileManager.getLocalBooksPath());
 		if (!bookPath.isDirectory()) {
-			System.err.println("ERROR:\tSpecified bookpath is not a directory");
-			System.err.println("\tPlease set a valid bookpath in larex.properties");
+			logger.error("Specified bookpath {} no directory, Please set a valid bookpath in larex.properties!",
+			bookPath);
 			return "redirect:/500";
 		}
 		FileDatabase database = new FileDatabase(bookPath, config.getListSetting("imagefilter"), false);
@@ -89,6 +95,7 @@ public class LibraryController {
 
 		model.addAttribute("library", lib);
 		model.addAttribute("timeStamp", timeStamp);
+		logger.info("Start LAREX using {}", this.fileManager.getConfigurationFile());
 		return "lib";
 	}
 
@@ -120,7 +127,7 @@ public class LibraryController {
 				case "flat":
 					return getFileMap(baseFolder.getAbsolutePath(), Constants.IMG_EXTENSIONS_DOTTED);
 				default:
-					System.out.println("Attempting to open empty directory");
+					logger.error("Attempt open empty directory {}", baseFolder.getAbsolutePath());
 					break;
 			}
 		} catch (Exception e) {
@@ -162,8 +169,13 @@ public class LibraryController {
 	 */
 	@RequestMapping(value = "library/getOldRequest", method = RequestMethod.POST, headers = "Accept=*/*")
 	public @ResponseBody DirectRequest getOldRequest() {
-		return fileManager.getDirectRequest();
+		DirectRequest directRequest = this.fileManager.getDirectRequest();
+		if (directRequest != null) {
+			logger.info("pass last {}", directRequest.getMetsPath());
+		}
+		return directRequest;
 	}
+	
 	/**
 	 * returns each imagePath in given directory
 	 * respecting the SubExtensionFilter set in properties
@@ -219,7 +231,14 @@ public class LibraryController {
 	@RequestMapping(value ="library/getVersion" , method = RequestMethod.GET)
 	public @ResponseBody
 	String getVersion() {
-		String larex_version = System.getenv("LAREX_VERSION");
-		return larex_version.equals("") ? "UNKNOWN" : larex_version;
+		logger.info("request LAREX_VERSION");
+		String larexVersion = "";
+		try {
+			larexVersion = System.getenv("LAREX_VERSION");
+			logger.info("request LAREX_VERSION: {}", larexVersion);
+		} catch (Exception e) {
+			logger.error("Unable to determine LAREX_VERSION: {}", e.getMessage());
+		}
+		return larexVersion.equals("") ? "UNKNOWN" : larexVersion;
 	}
 }

--- a/src/main/java/de/uniwue/web/controller/ViewerController.java
+++ b/src/main/java/de/uniwue/web/controller/ViewerController.java
@@ -13,6 +13,9 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.uniwue.web.communication.DirectRequest;
 import de.uniwue.web.io.MetsReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
@@ -35,6 +38,9 @@ import de.uniwue.web.model.Book;
 @Controller
 @Scope("request")
 public class ViewerController {
+
+	static Logger logger = LoggerFactory.getLogger(ViewerController.class);
+
 	@Autowired
 	private ServletContext servletContext;
 	@Autowired
@@ -99,8 +105,7 @@ public class ViewerController {
 			}
 			mimeMap = mapper.readValue(java.net.URLDecoder.decode(mimeMapString, StandardCharsets.UTF_8.name()), TreeMap.class);
 		} catch (IOException e) {
-			System.out.println(e.getMessage());
-			e.printStackTrace();
+			logger.error("Internal Exception {}", e.getMessage());
 			return "redirect:/error/500";
 		}
 		if(customFlag.equals("true") && !customFolder.endsWith(File.separator)) { customFolder += File.separator; }

--- a/src/main/java/de/uniwue/web/facade/segmentation/LarexFacade.java
+++ b/src/main/java/de/uniwue/web/facade/segmentation/LarexFacade.java
@@ -13,6 +13,8 @@ import de.uniwue.web.config.Constants;
 import de.uniwue.web.model.*;
 import org.opencv.core.Mat;
 import org.opencv.core.Size;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -31,6 +33,8 @@ import de.uniwue.web.io.SegmentationSettingsWriter;
  *  Facade between the LAREX Segmentation Algorithm and the Web GUI
  */
 public class LarexFacade {
+
+	static Logger logger = LoggerFactory.getLogger(LarexFacade.class);
 
 	/**
 	 * Segment a page with the LAREX segmentation algorithm
@@ -82,11 +86,9 @@ public class LarexFacade {
 			MemoryCleaner.clean(original);
 			segmentationResult = result;
 		} else {
-			System.err.println(
-					"Warning: Image file could not be found. Segmentation result will be empty. File: " + imagePath);
+			logger.warn("Image file {} could not be found. Segmentation will be empty!", imagePath);
 		}
 		// TODO fix metadata insertion here instead of frontend (?)
-
 		page.setOrientation(orientation);
 		if (segmentationResult != null) {
 			segmentation = new PageAnnotations(page.getName(), page.getXmlName(), page.getWidth(), page.getHeight(),

--- a/src/main/java/de/uniwue/web/io/FileDatabase.java
+++ b/src/main/java/de/uniwue/web/io/FileDatabase.java
@@ -165,7 +165,7 @@ public class FileDatabase {
 				if (metsFiles.length != 0) {
 					return "mets-data";
 				} else {
-					logger.warn("data folder {} exists but contains no mets", dataFolder.getAbsolutePath());
+					logger.warn("Data folder {} exists but contains no METS", dataFolder.getAbsolutePath());
 				}
 			}
 			return "empty";

--- a/src/main/java/de/uniwue/web/io/FileDatabase.java
+++ b/src/main/java/de/uniwue/web/io/FileDatabase.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 import de.uniwue.web.config.Constants;
 import org.apache.commons.io.FilenameUtils;
 import org.opencv.core.Size;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.uniwue.web.model.Book;
 import de.uniwue.web.model.Page;
@@ -37,6 +39,8 @@ import de.uniwue.web.model.Page;
  * ("." is a substitute for "no subextension")
  */
 public class FileDatabase {
+
+	static Logger logger = LoggerFactory.getLogger(FileDatabase.class);
 
 	private Map<Integer, File> books;
 	private File databaseFolder;
@@ -68,7 +72,8 @@ public class FileDatabase {
 	 * @param supportedFileExtensions supported image types to load
 	 * @param imageSubFilter     file extensions that are to be filtered
 	 */
-	public FileDatabase(File databaseFolder, List<String> supportedFileExtensions, List<String> imageSubFilter, Boolean isFlat) {
+	public FileDatabase(File databaseFolder, List<String> supportedFileExtensions, List<String> imageSubFilter,
+			Boolean isFlat) {
 		this.databaseFolder = databaseFolder;
 		this.books = new HashMap<Integer, File>();
 		this.supportedFileExtensions = new ArrayList<String>(supportedFileExtensions);
@@ -144,23 +149,23 @@ public class FileDatabase {
 	public String checkType(File bookfolder) {
 		File[] metsFiles = bookfolder.listFiles((d, name) -> name.endsWith("mets.xml"));
 		List<File> imgFileList = new ArrayList<>();
-		for(String ext : supportedFileExtensions) {
+		for (String ext : supportedFileExtensions) {
 			imgFileList.addAll(Arrays.asList(bookfolder.listFiles((d, name) -> name.endsWith(ext))));
 		}
 		File[] imgFiles = imgFileList.toArray(new File[0]);
-		if( metsFiles.length != 0) {
+		if (metsFiles.length != 0) {
 			return "mets";
-		} else if(imgFiles.length != 0) {
+		} else if (imgFiles.length != 0) {
 			return "flat";
 		} else {
-			//try ./data/mets.xml
+			// try ./data/mets.xml
 			File dataFolder = new File(bookfolder.getAbsolutePath() + File.separator + "data");
-			if(dataFolder.exists() && dataFolder.isDirectory()) {
+			if (dataFolder.exists() && dataFolder.isDirectory()) {
 				metsFiles = dataFolder.listFiles((d, name) -> name.endsWith("mets.xml"));
-				if( metsFiles.length != 0) {
+				if (metsFiles.length != 0) {
 					return "mets-data";
 				} else {
-					System.out.println("data folder exists but contains no mets");
+					logger.warn("data folder {} exists but contains no mets", dataFolder.getAbsolutePath());
 				}
 			}
 			return "empty";
@@ -208,12 +213,13 @@ public class FileDatabase {
 	 * Load a book object via Map.
 	 *
 	 * @param bookName name of book
-	 * @param bookID Identifier of the book to load
+	 * @param bookID   Identifier of the book to load
 	 * @param imageMap map of images from book
 	 * @return Loaded book
 	 */
-	public Book getBook(String bookName, Integer bookID,  Map<String, List<String>>  imageMap, Map<String, String> xmlMap) {
-		return readBook(bookName,imageMap, xmlMap, bookID);
+	public Book getBook(String bookName, Integer bookID, Map<String, List<String>> imageMap,
+			Map<String, String> xmlMap) {
+		return readBook(bookName, imageMap, xmlMap, bookID);
 	}
 
 	/**
@@ -256,14 +262,16 @@ public class FileDatabase {
 	 * @return Collection of all book pages in the selected book with a segmentation
 	 *         file
 	 */
-	public Collection<Integer> getPagesWithAnnotations(String bookName, Integer bookID,  Map<String, List<String>>  imageMap, Map<String, String> xmlMap) {
+	public Collection<Integer> getPagesWithAnnotations(String bookName, Integer bookID,
+			Map<String, List<String>> imageMap, Map<String, String> xmlMap) {
 		Collection<Integer> segmentedIds = new HashSet<>();
 		try {
-			Book book = getBook(bookName,bookID,imageMap, xmlMap);
+			Book book = getBook(bookName, bookID, imageMap, xmlMap);
 			for (Page page : book.getPages()) {
 				String key = page.getName();
 				String xmlKey = page.getXmlName().split("\\.")[0];
-				if ((xmlMap.get(key) != null && new File(xmlMap.get(key)).exists()) || (xmlMap.get(xmlKey) != null && new File(xmlMap.get(xmlKey)).exists())) {
+				if ((xmlMap.get(key) != null && new File(xmlMap.get(key)).exists())
+						|| (xmlMap.get(xmlKey) != null && new File(xmlMap.get(xmlKey)).exists())) {
 					segmentedIds.add(page.getId());
 				}
 
@@ -288,16 +296,18 @@ public class FileDatabase {
 		LinkedList<Page> pages = new LinkedList<Page>();
 		int pageCounter = 0;
 
-		if(imageSubFilter.isEmpty()) {
+		if (imageSubFilter.isEmpty()) {
 			// Interpret every image as its own page
 			List<File> imageFiles = Arrays.stream(Objects.requireNonNull(bookFile.listFiles()))
-					.filter(this::isSupportedImage).sorted(Comparator.comparing(File::getName)).collect(Collectors.toList());
+					.filter(this::isSupportedImage).sorted(Comparator.comparing(File::getName))
+					.collect(Collectors.toList());
 
-			for(File imageFile: imageFiles) {
+			for (File imageFile : imageFiles) {
 				Size imageSize = ImageLoader.readDimensions(imageFile);
 				String name = removeAllExtensions(imageFile.getName());
 				String imageURL = bookName + File.separator + imageFile.getName();
-				pages.add(new Page(pageCounter++, name, name + ".xml", Collections.singletonList(imageURL), (int) imageSize.width, (int) imageSize.height, 0.0));
+				pages.add(new Page(pageCounter++, name, name + ".xml", Collections.singletonList(imageURL),
+						(int) imageSize.width, (int) imageSize.height, 0.0));
 			}
 
 		} else {
@@ -315,13 +325,13 @@ public class FileDatabase {
 				List<String> images = new ArrayList<>();
 
 				Size imageSize = null;
-				for(String subExtension: imageSubFilter) {
+				for (String subExtension : imageSubFilter) {
 					List<File> subImages = !subExtension.equals(".") ? groupedImages.get(subExtension)
-												: groupedImages.get("");
+							: groupedImages.get("");
 
-					if(subImages != null) {
-						for(File subImage: subImages) {
-							if(imageSize == null) {
+					if (subImages != null) {
+						for (File subImage : subImages) {
+							if (imageSize == null) {
 								imageSize = ImageLoader.readDimensions(subImage);
 							}
 							images.add(bookName + File.separator + subImage.getName());
@@ -330,7 +340,8 @@ public class FileDatabase {
 				}
 
 				assert imageSize != null;
-				pages.add(new Page(pageCounter++, pageName, pageName + ".xml", images, (int) imageSize.width, (int) imageSize.height, 0.0));
+				pages.add(new Page(pageCounter++, pageName, pageName + ".xml", images, (int) imageSize.width,
+						(int) imageSize.height, 0.0));
 			}
 		}
 
@@ -345,17 +356,18 @@ public class FileDatabase {
 	 * @param bookID   Identifier that is to be used for the loaded book
 	 * @return
 	 */
-	private Book readBook(String bookName,  Map<String, List<String>>  imagemap, Map<String, String> xmlMap, int bookID) {
-		try{
+	private Book readBook(String bookName, Map<String, List<String>> imagemap, Map<String, String> xmlMap, int bookID) {
+		try {
 			LinkedList<Page> pages = new LinkedList<Page>();
 			int pageCounter = 0;
-			for(Entry<String, List<String>> imgEntry: imagemap.entrySet()) {
+			for (Entry<String, List<String>> imgEntry : imagemap.entrySet()) {
 				File imageFile = new File(imgEntry.getValue().get(0));
 				Size imageSize = ImageLoader.readDimensions(imageFile);
 				String name = removeAllExtensions(imageFile.getName());
 				String xmlName = (new File(xmlMap.get(imgEntry.getKey()))).getName();
-				if(isSupportedImage(imageFile)) {
-					pages.add(new Page(pageCounter++, name, xmlName, imgEntry.getValue(), (int) imageSize.width, (int) imageSize.height));
+				if (isSupportedImage(imageFile)) {
+					pages.add(new Page(pageCounter++, name, xmlName, imgEntry.getValue(), (int) imageSize.width,
+							(int) imageSize.height));
 				}
 			}
 			return new Book(bookID, bookName, pages);
@@ -419,13 +431,13 @@ public class FileDatabase {
 		if (passesSubFilter(filename)) {
 			final int extPointPos = filename.lastIndexOf(".");
 			final int subExtPointPos = filename.lastIndexOf(".", extPointPos - 1);
-			if(subExtPointPos > 0)
+			if (subExtPointPos > 0)
 				return filename.substring(0, subExtPointPos);
 			else
 				return filename.substring(0, extPointPos);
 		} else {
 			final int extensionPointer = filename.lastIndexOf(".");
-			if(extensionPointer > 0)
+			if (extensionPointer > 0)
 				return filename.substring(0, extensionPointer);
 
 		}

--- a/src/main/java/de/uniwue/web/io/PageXMLReader.java
+++ b/src/main/java/de/uniwue/web/io/PageXMLReader.java
@@ -1,6 +1,7 @@
 package de.uniwue.web.io;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -28,6 +29,8 @@ import org.primaresearch.dla.page.metadata.MetaData;
 import org.primaresearch.shared.variable.IntegerValue;
 import org.primaresearch.shared.variable.IntegerVariable;
 import org.primaresearch.shared.variable.Variable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.uniwue.algorithm.geometry.regions.type.PAGERegionType;
 import de.uniwue.algorithm.geometry.regions.type.RegionSubType;
@@ -60,6 +63,8 @@ import javax.xml.xpath.XPathFactory;
  */
 public class PageXMLReader {
 
+	static Logger logger = LoggerFactory.getLogger(PageXMLReader.class);
+
 	/**
 	 * Read a document to extract the PageAnnotations
 	 *
@@ -78,8 +83,7 @@ public class PageXMLReader {
 				fixFaultyPAGE(sourceFilename);
 				page = readPAGE(sourceFilename);
 			}catch (ParserConfigurationException | IOException | SAXException | XPathExpressionException e) {
-				e.printStackTrace();
-				System.err.println("Could not load source PAGE XML file: " + sourceFilename);
+				logger.error("Could not load source PAGE XML file {}: {}", sourceFilename, e.getMessage());
 			}
 		}
 
@@ -233,12 +237,13 @@ public class PageXMLReader {
 	public static Page readPAGE(File sourceFilename){
 		Page page = null;
 		try{
+			if (! sourceFilename.exists()) {
+				throw new FileNotFoundException(sourceFilename.getAbsolutePath());
+			}
 			page = PageXmlInputOutput.readPage(String.valueOf(sourceFilename));
 		}catch(Exception e){
-			e.printStackTrace();
-			System.err.println("Could not load source PAGE XML file: " + sourceFilename);
+			logger.error("Could not load source PAGE XML file {}: {} ", sourceFilename, e.getMessage());
 		}
-
 		return page;
 	}
 
@@ -311,8 +316,7 @@ public class PageXMLReader {
 		try {
 			segResult = getPageAnnotations(pageXMLInputPath);
 		} catch (Exception e) {
-			e.printStackTrace();
-			System.err.println("Reading XML file failed!");
+			logger.error("Failed to read {}: {}", pageXMLInputPath, e.getMessage());
 		}
 
 		return segResult;

--- a/src/main/java/de/uniwue/web/io/SegmentationSettingsReader.java
+++ b/src/main/java/de/uniwue/web/io/SegmentationSettingsReader.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -20,6 +22,9 @@ import de.uniwue.algorithm.segmentation.parameters.Parameters;
  * Parameters for the segmentation steps.
  */
 public class SegmentationSettingsReader {
+
+	static Logger logger = LoggerFactory.getLogger(SegmentationSettingsReader.class);
+
 	/**
 	 * Read a settingsfile from a document into Parameters
 	 *
@@ -37,8 +42,7 @@ public class SegmentationSettingsReader {
 			RegionManager regionmanager = extractRegions(regionNodes);
 			parameters = extractParameters(parameterElement, regionmanager);
 		} catch (Exception e) {
-			e.printStackTrace();
-			System.out.println("Reading XML file failed!");
+			logger.error("Failed to process {}: {}", document.getDocumentURI(), e.getMessage());
 		}
 		return parameters;
 	}

--- a/src/main/java/de/uniwue/web/model/PageAnnotations.java
+++ b/src/main/java/de/uniwue/web/model/PageAnnotations.java
@@ -1,11 +1,13 @@
 package de.uniwue.web.model;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -19,6 +21,9 @@ import de.uniwue.web.config.Constants;
  * segment polygons.
  */
 public class PageAnnotations {
+
+	static Logger logger = LoggerFactory.getLogger(PageAnnotations.class);
+
 	/**
 	 * Name of the page (does not include image extensions)
 	 * Does not include sub extensions if imageSubFilter is active
@@ -181,9 +186,8 @@ public class PageAnnotations {
 		final List<String> imageExtensions = Constants.IMG_EXTENSIONS_DOTTED;
 		for (String ext : imageExtensions) {
 			if(name.toLowerCase().endsWith(ext))
-				System.err.println("[Warning] Page name '"+name+"' ends with an image extension ('"+ext+"').\n"+
-								   "\tThis should not happen unless '"+ext+"' is part of the page name.\n"+
-								   "\te.g. '"+name+".png'");
+				logger.error("Page {} ends with image extension ({}). This should not happen unless it's part of page name, i.e. {}.png", 
+				name, ext, name);
 		}
 
 	}

--- a/src/main/java/de/uniwue/web/model/PageAnnotations.java
+++ b/src/main/java/de/uniwue/web/model/PageAnnotations.java
@@ -186,7 +186,7 @@ public class PageAnnotations {
 		final List<String> imageExtensions = Constants.IMG_EXTENSIONS_DOTTED;
 		for (String ext : imageExtensions) {
 			if(name.toLowerCase().endsWith(ext))
-				logger.error("Page {} ends with image extension ({}). This should not happen unless it's part of page name, i.e. {}.png", 
+				logger.error("Page {} ends with image extension ({}). This should not happen unless it's part of the page name, i.e. {}.png",
 				name, ext, name);
 		}
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>/home/ocr/larex-local.log</file>
+        <file>${user.home}/larex.log</file>
         <append>true</append>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-5level][%logger{36}] %msg%n</pattern>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,8 +1,7 @@
 <configuration debug="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-5level][%logger{36}] %msg%n
-            </pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-5level][%logger{36}] %msg%n</pattern>
         </encoder>
     </appender>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
@@ -13,8 +12,9 @@
         </encoder>
     </appender>
 
-    <logger name="de.uniwue" level="info" additivity="false">
+    <logger name="de.uniwue" level="debug" additivity="false">
         <appender-ref ref="FILE" />
+        <appender-ref ref="STDOUT" />
     </logger>
 
     <root level="error">

--- a/src/main/webapp/resources/logback.xml
+++ b/src/main/webapp/resources/logback.xml
@@ -1,0 +1,23 @@
+<configuration debug="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-5level][%logger{36}] %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>/home/ocr/larex-local.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-5level][%logger{36}] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="de.uniwue" level="info" additivity="false">
+        <appender-ref ref="FILE" />
+    </logger>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/test/java/de/uniwue/web/io/TestPageXMLReader.java
+++ b/src/test/java/de/uniwue/web/io/TestPageXMLReader.java
@@ -2,6 +2,7 @@ package de.uniwue.web.io;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
@@ -16,6 +17,9 @@ import org.primaresearch.dla.page.Page;
  */
 public class TestPageXMLReader {
 
+	/**
+	 * Ensure Legacy validated Transkribus format read as expected
+	 */
 	@Test
 	public void testReadTranskribusPAGE2013() {
 		// arrange
@@ -29,6 +33,15 @@ public class TestPageXMLReader {
 		// assert
 		assertNotNull(readPage);
 		assertEquals(34, readPage.getLayout().getRegionCount());
+	}
+
+	/**
+	 * Test behavior if invalid sourceFilename=Null used
+	 */
+	@Test
+	public void testNullpointerInputFile() {
+
+		assertNull(PageXMLReader.readPAGE(null));
 	}
 
 }


### PR DESCRIPTION
# Description

The main rationale behind this PR is to replace any usage of  `System.err.println` or `System.out.println` by a dedicated Logger to be able to persist those information for later investigation in case of errors.

The Logging uses `slf4j-api` and the implementation of `ch.qos.logback` , since the latter is preferred by the spring framework which is used throughout the actual service implementation.

Sample logging configuration included at `src/main/webapp/resources/logback.xml`.
